### PR TITLE
Add support to show current user name in title.

### DIFF
--- a/far/FarEng.hlf.m4
+++ b/far/FarEng.hlf.m4
@@ -2643,6 +2643,7 @@ Can contain any text, including the following variables:
   - #%Platform# - Far platform;
   - #%Admin# - ^<wrap>"Administrator" if running as administrator, otherwise an empty string.
   - #%PID# - Far process ID;
+  - #%UserName - Current User Name (can be usefull in case you run FarManager as different user)
 
 
 @DialogSettings

--- a/far/changelog_eng
+++ b/far/changelog_eng
@@ -2,6 +2,9 @@
 This file is a translation of the main russian changelog and is provided by volunteers.
 It might not always be as up to date as the main changelog.
 =======================================================================================
+pmisik 08.11.2017 00:00:00 +0000 - build 5092
+
+1. Add support to show current user name in title. It is useful in case you run FarManager as different user.
 
 drkns 05.11.2017 15:25:38 +0000 - build 5091
 

--- a/far/constitle.cpp
+++ b/far/constitle.cpp
@@ -42,6 +42,14 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "farversion.hpp"
 #include "scrbuf.hpp"
 #include "strmix.hpp"
+#include "platform.hpp"
+
+static string GetUserNameInternal()
+{
+	string strUserName;
+	os::GetUserName(strUserName);
+	return strUserName;
+}
 
 static const string& GetFarTitleAddons()
 {
@@ -61,6 +69,7 @@ static const string& GetFarTitleAddons()
 	static const string strVer = concat(str(FAR_VERSION.Major), L'.', str(FAR_VERSION.Minor));
 	static const string strBuild = str(FAR_VERSION.Build);
 	static const string strPID = str(GetCurrentProcessId());
+	static const string strUserName = GetUserNameInternal();
 
 	ReplaceStrings(strTitleAddons, L"%PID", strPID, true);
 	ReplaceStrings(strTitleAddons, L"%Ver", strVer, true);
@@ -77,6 +86,7 @@ static const string& GetFarTitleAddons()
 #endif
 	true);
 	ReplaceStrings(strTitleAddons, L"%Admin", os::security::is_admin() ? msg(lng::MFarTitleAddonsAdmin) : L"", true);
+	ReplaceStrings(strTitleAddons, L"%UserName", strUserName, true);
 	RemoveTrailingSpaces(strTitleAddons);
 
 	return strTitleAddons;


### PR DESCRIPTION
This can be useful if you run FarManager as different user.