### PR TITLE
Add initial .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,33 @@
+# Handle line endings automatically for files detected as text
+# and leave all files detected as binary untouched.
+* text=auto
+
+#
+# The above will handle all files NOT found below
+#
+# These files are text and should be normalized (Convert crlf => lf)
+*.bat           text    eol=crlf
+*.cmd           text    eol=crlf
+*.cs            text    diff=csharp
+*.sh            text    eol=lf
+[Cc]hangelog    text
+changelog_eng   text
+
+# Custom for Visual Studio
+*.sln           text    merge=union  eol=crlf
+*.csproj                merge=union
+*.vcproj                merge=union
+*.vcxproj               merge=union
+
+# These files are binary and should be left untouched
+# (binary is a macro for -text -diff)
+*.bmp           binary
+*.dll           binary
+*.exe           binary
+*.gif           binary
+*.ico           binary
+*.jpg           binary
+*.lib           binary
+*.obj           binary
+*.png           binary
+*.sfx           binary


### PR DESCRIPTION
Fixes detection of changelog as binary file and adds some rules for
non-standard handling of some file types.

Best practice is to add all text file types used in the project.