### PR TITLE
Fixed VC15 64-bit compilation error C3487.

### DIFF
--- a/far/changelog
+++ b/far/changelog
@@ -1,3 +1,7 @@
+MZK 21.02.2018 22:37:57 -0800 - build 5149
+
+1. Пофиксил ошибку компиляции в VC15 64-бит: C3487: 'int': all return expressions must deduce to the same type: previously it was '__int64'.
+
 drkns 21.02.2018 21:29:53 +0000 - build 5148
 
 1. Числовая сортировка теперь больше похожа на "как в Windows" в плане обработки идущих подряд нулей.

--- a/far/changelog_eng
+++ b/far/changelog_eng
@@ -3,6 +3,20 @@ This file is a translation of the main russian changelog and is provided by volu
 It might not always be as up to date as the main changelog.
 =======================================================================================
 
+MZK 21.02.2018 22:37:57 -0800 - build 5149
+
+1. Fixed VC15 64-bit compilation error: C3487: 'int': all return expressions must deduce to the same type: previously it was '__int64'.
+
+drkns 21.02.2018 21:29:53 +0000 - build 5148
+
+1. Numeric sort is now more like "as in Windows" with regard to sequences of zeros.
+
+2. In Windows 7 and above, the system function (SORT_DIGITSASNUMBERS) is used for case-insensitive numeric sort.
+
+drkns 21.02.2018 01:56:58 +0000 - build 5147
+
+1. Show module name in the stack trace.
+
 zg 17.02.2018 17:43:21 +0200 - build 5146
 
 1. 0003580: Text in input field is shifted when entering text in another field.

--- a/far/string_utils.cpp
+++ b/far/string_utils.cpp
@@ -294,7 +294,7 @@ static int NumStrCmp_base(const string_view& Str1, const string_view& Str2, int(
 			It2 = std::find_if(It2, End2, NotZero);
 
 			// 00 is less than 0 in Windows numeric sort implementation
-			const auto ZerosResult = (It2 - Begin2) - (It1 - Begin1);
+			const auto ZerosResult = static_cast<int>((It2 - Begin2) - (It1 - Begin1));
 
 			if (It1 == End1 && It2 == End2)
 				return ZerosResult;

--- a/far/vbuild.m4
+++ b/far/vbuild.m4
@@ -1,1 +1,1 @@
-m4_define(BUILD,5148)m4_dnl
+m4_define(BUILD,5149)m4_dnl


### PR DESCRIPTION
In 64-bit mode, VC15 (2017) compiler complained about a lambda where it could not deduce return type:
```
string_utils.cpp(319,1): error C3487: 'int': all return expressions must deduce to the same type: previously it was '__int64'
                        return EndOrNonDigit1? -1 : 1;
string_utils.cpp(322,1): error C3487: 'int': all return expressions must deduce to the same type: previously it was '__int64'
                return Comparer({ It1++, 1 }, { It2++, 1 });
```
This happened because `ZerosResult` returned above was defined `auto` and deduced from `ptrdiff_t`.

Fixed by `static_cast<int>`ing the initializer of `ZerosResult`.