### PR TITLE
nightly/enc.sh: Build enc in repository root _output/enc

### DIFF
--- a/misc/nightly/enc.sh
+++ b/misc/nightly/enc.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# absolute path to this script
+DIR=$(dirname $(readlink -f $0))
+# absolute path to source root
+ROOT=$(cd $DIR/../.. && pwd)
+BUILDDIR=$ROOT/_output
+
+
 function benc2 {
 LNG=$1
 L=$2
@@ -8,8 +15,8 @@ cd ${LNG} || return 1
 wine "C:/Program Files (x86)/HTML Help Workshop/hhc.exe" plugins${L}.hhp
 
 ( \
-	cp -f FarEncyclopedia.${LNG}.chm ../../../../outfinalnew32/Encyclopedia/ && \
-	cp -f FarEncyclopedia.${LNG}.chm ../../../../outfinalnew64/Encyclopedia/ \
+	cp -vf FarEncyclopedia.${LNG}.chm $BUILDDIR/outfinalnew32/Encyclopedia/ && \
+	cp -vf FarEncyclopedia.${LNG}.chm $BUILDDIR/outfinalnew64/Encyclopedia/ \
 ) || return 1
 
 cd ..
@@ -25,22 +32,26 @@ wine "C:/src/enc/tools/lua/lua.exe" "C:/src/enc/tools/lua/scripts/tp2hh.lua" "..
 wine "C:/Program Files (x86)/HTML Help Workshop/hhc.exe" ${1}.hhp
 
 ( \
-	cp -f ${1}.chm ../../../../outfinalnew32/Encyclopedia/ && \
-	cp -f ${1}.chm ../../../../outfinalnew64/Encyclopedia/ \
+	cp -f ${1}.chm $BUILDDIR/outfinalnew32/Encyclopedia/ && \
+	cp -f ${1}.chm $BUILDDIR/outfinalnew64/Encyclopedia/ \
 ) || return 1
 
 cd ..
 
 }
 
-rm -fR enc
 
-cp -R far.git/enc ./ || exit 1
+echo Building in $BUILDDIR
+echo Cleaning up $BUILDDIR
+rm -fR $BUILDDIR
+mkdir $BUILDDIR
 
-mkdir -p outfinalnew32/Encyclopedia
-mkdir -p outfinalnew64/Encyclopedia
+cp -R $ROOT/enc $BUILDDIR/ || exit 1
 
-pushd enc/tools || exit 1
+mkdir -p $BUILDDIR/outfinalnew32/Encyclopedia
+mkdir -p $BUILDDIR/outfinalnew64/Encyclopedia
+
+pushd $BUILDDIR/enc/tools || exit 1
 python tool.make_chm.py
 cd ../build/chm
 
@@ -51,8 +62,8 @@ cd ../build/chm
 
 popd
 
-mkdir -p enc/build/lua
-pushd enc/build/lua || exit 1
+mkdir -p $BUILDDIR/enc/build/lua
+pushd $BUILDDIR/enc/build/lua || exit 1
 
 ( \
 	blua macroapi_manual.ru && \
@@ -63,8 +74,10 @@ pushd enc/build/lua || exit 1
 popd
 
 #update api.farmanager.com
-pushd enc/tools || exit 1
+pushd $BUILDDIR/enc/tools || exit 1
 python ./tool.make_inet.py || exit 1
-popd 
+popd
+
+#TODO this should belong to deploy script
 rm -Rf /var/www/api/* || exit 1
-cp -Rf enc/build/inet/* /var/www/api/ || exit 1
+cp -Rf $BUILDDIR/enc/build/inet/* /var/www/api/ || exit 1


### PR DESCRIPTION
nighly build files for Encyclopedia will be available at:

    _output/outfinalnew32/Encyclopedia
    _output/outfinalnew64/Encyclopedia

And the build itself is taking place in:

    _output/enc  - which is a 1:1 copy from the repo