### PR TITLE
at 30.06.2018 08:09:00 -0800 - build 5235

### DIFF
--- a/far/FarEng.hlf.m4
+++ b/far/FarEng.hlf.m4
@@ -339,25 +339,36 @@ $ #Panel control commands#
   Restore default panels width                          #Ctrl+Numpad5#
   Restore default panels height                     #Ctrl+Alt+Numpad5#
   Show/Hide functional key bar at the bottom line.            #Ctrl+B#
-  Toggle total and free size show mode                  #Ctrl+Shift+S#
-   in bytes (if possible) or with size suffices K/M/G/T
+  Toggle total and free size show mode
+    if 'Don't use numeric keypad' is not selected:      #Ctrl+Shift+S#
+    if 'Don't use numeric keypad' is selected:            #Ctrl+Alt+S#
+    in bytes (if possible) or with size suffices K/M/G/T
 
     #File panel commands#
 
   ~Select/deselect file~@SelectFiles@                        #Ins, Shift+Cursor keys#
                                                   #Right mouse button#
+    if 'Don't use numeric keypad' is selected:          #Ctrl+Shift+E#
   Select group                                                #Gray +#
+    if 'Don't use numeric keypad' is selected:          #Ctrl+Shift+S#
   Deselect group                                              #Gray -#
+    if 'Don't use numeric keypad' is selected:          #Ctrl+Shift+D#
   Invert selection                                            #Gray *#
+    if 'Don't use numeric keypad' is selected:          #Ctrl+Shift+X#
   Select files with the same extension as the          #Ctrl+<Gray +>#
     current file
+    if 'Don't use numeric keypad' is selected:          #Ctrl+Shift+A#
   Deselect files with the same extension as the        #Ctrl+<Gray ->#
     current file
+    if 'Don't use numeric keypad' is selected:          #Ctrl+Shift+F#
   Invert selection including folders                   #Ctrl+<Gray *>#
     (ignore command line state)
+    if 'Don't use numeric keypad' is selected:          #Ctrl+Shift+Z#
   Select files with the same name as the current file   #Alt+<Gray +>#
+    if 'Don't use numeric keypad' is selected:          #Ctrl+Shift+G#
   Deselect files with the same name as the current      #Alt+<Gray ->#
     file
+    if 'Don't use numeric keypad' is selected:          #Ctrl+Shift+H#
   Select all files                                    #Shift+<Gray +>#
   Deselect all files                                  #Shift+<Gray ->#
   Restore previous selection                                  #Ctrl+M#
@@ -407,13 +418,17 @@ $ #Panel control commands#
   Copy the files to clipboard                                 #Ctrl+C#
    (ignore command line state)
    ^<wrap>Files, copied from the panels, can be pasted to other applications,
-e.g. Explorer.
+e.g. Explorer. If 'Don't use numeric keypad' mode is selected, #Ctrl+C# acts
+the same way as #Ctrl+Ins# does.
   Copy the names of selected files to the clipboard   #Ctrl+Shift+Ins#
+                                                        #Ctrl+Shift+C#
    (ignore command line state)
   Copy full names of selected files to the clipboard   #Alt+Shift+Ins#
+                                                         #Alt+Shift+C#
    (ignore command line state)
   Copy network (UNC) names of selected files to the     #Ctrl+Alt+Ins#
-   clipboard (ignore command line state)
+   clipboard                                              #Ctrl+Alt+C#
+   (ignore command line state)
 
   See also the list of ~macro keys~@KeyMacroShellList@, available in the panels.
 
@@ -2441,6 +2456,25 @@ correctly (this can happen because of bugs in the drivers of some CD-ROM drives)
   #Automatic update of environment variables#
   Automatically update the environment variables if they have been changed globally.
 
+  #Don't use numeric keypad#
+  For small form-factor laptops, it's quite common to not have a numeric keypad on the keyboard.
+By selecting this option numeric keypad-only actions (#Gray -#, #Gray +#, #Ins#, etc.) are re-mapped
+to other key combinations. The most important changes are:
+  #Ctrl-Shift-E#:                                 ~Select/deselect file~@SelectFiles@
+  #Ctrl+Shift+S#:                                         Select group
+  #Ctrl+Shift+D#:                                       Deselect group
+  #Ctrl+Shift+X#:                                     Invert selection
+  #Ctrl+Shift+A#:                 Select files with the same extension
+                                                 as the current file
+  #Ctrl+Shift+F#:               Deselect files with the same extension
+                                                 as the current file
+  #Ctrl+Shift+Z#:                   Invert selection including folders
+  #Ctrl+Shift+G#:                      Select files with the same name
+                                                 as the current file
+  #Ctrl+Shift+H#:                    Deselect files with the same name
+                                                 as the current file
+  #Ctrl+C#:                              Acts the same way as #Ctrl+Ins#
+
   #Request administrator rights#
   The current user might not always has the required rights to work with certain file system objects.
 Far allows to retry the operation using the privileged account.
@@ -3011,6 +3045,7 @@ behavior can be changed in the ~Editor settings~@EditorSettings@ dialog.
    #Shift+Del, Ctrl+X#       Cut block
    #Ctrl+Ins, Ctrl+C#        Copy block to clipboard
    #Ctrl+<Gray +>#           Append block to clipboard
+   #Ctrl+Shift+A#            Append block to clipboard
    #Ctrl+D#                  Delete block
    #Ctrl+P#                  ^<wrap>Copy block to current cursor position (in persistent blocks mode only)
    #Ctrl+M#                  ^<wrap>Move block to current cursor position (in persistent blocks mode only)
@@ -3052,6 +3087,7 @@ behavior can be changed in the ~Editor settings~@EditorSettings@ dialog.
    #Ctrl+F#                  ^<wrap>Insert the full name of the file being edited at the cursor position.
    #Ctrl+B#                  ^<wrap>Show/Hide functional key bar at the bottom line.
    #Ctrl+Shift+B#            Show/Hide status line
+   #Ins, Ctrl+O#             Toggle between insert and overwrite mode
 
    See also the list of ~macro keys~@KeyMacroEditList@, available in the editor.
 

--- a/far/changelog
+++ b/far/changelog
@@ -1,3 +1,9 @@
+at 30.06.2018 08:09:00 -0800 - build 5235
+
+1. Added new key-mappings to support laptops with no numeric keypad
+   Added new 'Don't use numeric keypad' option (default off) to toggle some conflicting or changed behavior
+   Changed (English) help to describe changes
+
 drkns 29.06.2018 20:49:29 +0100 - build 5234
 
 1. #54: Far crashes when trying to free up memory used to store Descript.ion file records

--- a/far/config.cpp
+++ b/far/config.cpp
@@ -172,6 +172,7 @@ void Options::SystemSettings()
 	Builder.AddCheckbox(lng::MConfigSaveViewHistory, SaveViewHistory);
 	Builder.AddCheckbox(lng::MConfigRegisteredTypes, UseRegisteredTypes);
 	Builder.AddCheckbox(lng::MConfigUpdateEnvironment, UpdateEnvironment);
+	Builder.AddCheckbox(lng::MConfigNoNumericPad, NoNumericPad);
 	Builder.AddText(lng::MConfigElevation);
 	Builder.AddCheckbox(lng::MConfigElevationModify, StoredElevationMode, ELEVATION_MODIFY_REQUEST)->Indent(4);
 	Builder.AddCheckbox(lng::MConfigElevationRead, StoredElevationMode, ELEVATION_READ_REQUEST)->Indent(4);
@@ -1915,6 +1916,7 @@ void Options::InitConfigsData()
 		{FSSF_PRIVATE,       NKeyScreen, L"ViewerEditorClock", OPT_DEF(ViewerEditorClock, true)},
 
 		{FSSF_PRIVATE,       NKeySystem,L"AllCtrlAltShiftRule", OPT_DEF(AllCtrlAltShiftRule, 0x0000FFFF)},
+		{FSSF_PRIVATE,       NKeySystem,L"NoNumericPad", OPT_DEF(NoNumericPad, false)},
 		{FSSF_PRIVATE,       NKeySystem,L"AutoSaveSetup", OPT_DEF(AutoSaveSetup, false)},
 		{FSSF_PRIVATE,       NKeySystem,L"AutoUpdateRemoteDrive", OPT_DEF(AutoUpdateRemoteDrive, true)},
 		{FSSF_PRIVATE,       NKeySystem,L"BoxSymbols", OPT_DEF(strBoxSymbols, DefaultBoxSymbols)},

--- a/far/config.hpp
+++ b/far/config.hpp
@@ -722,6 +722,7 @@ public:
 	StringOption strQuotedSymbols;
 	IntOption QuotedName;
 	BoolOption AutoSaveSetup;
+	BoolOption NoNumericPad;
 	IntOption ChangeDriveMode;
 	BoolOption ChangeDriveDisconnectMode;
 

--- a/far/edit.cpp
+++ b/far/edit.cpp
@@ -1055,7 +1055,7 @@ bool Edit::ProcessKey(const Manager::Key& Key)
 			Show();
 			return true;
 		}
-		case KEY_INS:         case KEY_NUMPAD0:
+		case KEY_INS:         case KEY_NUMPAD0:      case KEY_ALTO:
 		{
 			m_Flags.Invert(FEDITLINE_OVERTYPE);
 			Show();

--- a/far/editor.cpp
+++ b/far/editor.cpp
@@ -1382,6 +1382,7 @@ bool Editor::ProcessKeyInternal(const Manager::Key& Key, bool& Refresh)
 		}
 		case KEY_CTRLADD:
 		case KEY_RCTRLADD:
+		case KEY_CTRLSHIFTA:
 		{
 			Copy(TRUE);
 			return true;
@@ -1540,7 +1541,7 @@ bool Editor::ProcessKeyInternal(const Manager::Key& Key, bool& Refresh)
 			return true;
 		}
 
-		case KEY_INS: case KEY_NUMPAD0:
+		case KEY_INS: case KEY_NUMPAD0: case KEY_ALTO:
 			m_Flags.Invert(FEDITOR_OVERTYPE);
 			Refresh = true;
 			return true;

--- a/far/farlang.templ.m4
+++ b/far/farlang.templ.m4
@@ -1792,6 +1792,18 @@ upd:"Automatic update of environment variables"
 "Aggiorna Varia&bili Ambiente Automaticamente"
 "Автооновл&ення змінних оточення"
 
+MConfigNoNumericPad
+upd:"D&on't use numeric keypad"
+"D&on't use numeric keypad"
+upd:"D&on't use numeric keypad"
+upd:"D&on't use numeric keypad"
+"Ne használj numerikus billentyűzetet"
+upd:"D&on't use numeric keypad"
+upd:"D&on't use numeric keypad"
+upd:"D&on't use numeric keypad"
+upd:"D&on't use numeric keypad"
+upd:"D&on't use numeric keypad"
+
 MConfigElevation
 "Запрос прав администратора:"
 "Request administrator rights:"

--- a/far/filelist.cpp
+++ b/far/filelist.cpp
@@ -1266,39 +1266,51 @@ bool FileList::ProcessKey(const Manager::Key& Key)
 			return true;
 
 		case KEY_ADD:
+		case KEY_CTRLSHIFTS:    case KEY_RCTRLSHIFTS:
+			if (!Global->Opt->NoNumericPad)
+			{
+				if (LocalKey == KEY_CTRLSHIFTS || LocalKey == KEY_RCTRLSHIFTS) return false;
+			}
 			SelectFiles(SELECT_ADD);
 			return true;
 
 		case KEY_SUBTRACT:
+		case KEY_CTRLSHIFTD:    case KEY_RCTRLSHIFTD:
 			SelectFiles(SELECT_REMOVE);
 			return true;
 
 		case KEY_CTRLADD:
 		case KEY_RCTRLADD:
+		case KEY_CTRLSHIFTA:    case KEY_RCTRLSHIFTA:
 			SelectFiles(SELECT_ADDEXT);
 			return true;
 
 		case KEY_CTRLSUBTRACT:
 		case KEY_RCTRLSUBTRACT:
+		case KEY_CTRLSHIFTF:    case KEY_RCTRLSHIFTF:
 			SelectFiles(SELECT_REMOVEEXT);
 			return true;
 
 		case KEY_ALTADD:
 		case KEY_RALTADD:
+		case KEY_CTRLSHIFTG:    case KEY_RCTRLSHIFTG:
 			SelectFiles(SELECT_ADDNAME);
 			return true;
 
 		case KEY_ALTSUBTRACT:
 		case KEY_RALTSUBTRACT:
+		case KEY_CTRLSHIFTH:    case KEY_RCTRLSHIFTH:
 			SelectFiles(SELECT_REMOVENAME);
 			return true;
 
 		case KEY_MULTIPLY:
+		case KEY_CTRLSHIFTX:    case KEY_RCTRLSHIFTX:
 			SelectFiles(SELECT_INVERT);
 			return true;
 
 		case KEY_CTRLMULTIPLY:
 		case KEY_RCTRLMULTIPLY:
+		case KEY_CTRLSHIFTZ:    case KEY_RCTRLSHIFTZ:
 			SelectFiles(SELECT_INVERTALL);
 			return true;
 
@@ -1318,6 +1330,14 @@ bool FileList::ProcessKey(const Manager::Key& Key)
 			Redraw();
 			return true;
 
+		case KEY_CTRLC: // hdrop  copy
+		case KEY_RCTRLC:
+			if (!Global->Opt->NoNumericPad)
+			{
+				CopyFiles();
+				return true;
+			}
+			[[fallthrough]];
 		case KEY_CTRLINS:      case KEY_CTRLNUMPAD0:
 		case KEY_RCTRLINS:     case KEY_RCTRLNUMPAD0:
 			if (!IsEmptyCmdline)
@@ -1331,20 +1351,25 @@ bool FileList::ProcessKey(const Manager::Key& Key)
 		case KEY_RCTRLALTINS:   case KEY_RCTRLALTNUMPAD0:
 		case KEY_ALTSHIFTINS:   case KEY_ALTSHIFTNUMPAD0:   // копировать полные имена
 		case KEY_RALTSHIFTINS:  case KEY_RALTSHIFTNUMPAD0:
+		case KEY_CTRLSHIFTC:  // копировать имена
+		case KEY_RCTRLSHIFTC:
+		case KEY_CTRLALTC:    // копировать UNC-имена
+		case KEY_RCTRLRALTC:
+		case KEY_CTRLRALTC:
+		case KEY_RCTRLALTC:
+		case KEY_ALTSHIFTC:   // копировать полные имена
+		case KEY_RALTSHIFTC:
 			//if (FileCount>0 && SetCurPath()) // ?????
 			SetCurPath();
 			CopyNames(
 					LocalKey == KEY_CTRLALTINS || LocalKey == KEY_RCTRLRALTINS || LocalKey == KEY_CTRLRALTINS || LocalKey == KEY_RCTRLALTINS ||
 					LocalKey == KEY_ALTSHIFTINS || LocalKey == KEY_RALTSHIFTINS ||
+					LocalKey == KEY_CTRLALTC ||
+					LocalKey == KEY_ALTSHIFTC ||
 					LocalKey == KEY_CTRLALTNUMPAD0 || LocalKey == KEY_RCTRLRALTNUMPAD0 || LocalKey == KEY_CTRLRALTNUMPAD0 || LocalKey == KEY_RCTRLALTNUMPAD0 ||
 					LocalKey == KEY_ALTSHIFTNUMPAD0 || LocalKey == KEY_RALTSHIFTNUMPAD0,
 				(LocalKey&(KEY_CTRL|KEY_ALT))==(KEY_CTRL|KEY_ALT) || (LocalKey&(KEY_RCTRL|KEY_RALT))==(KEY_RCTRL|KEY_RALT)
 			);
-			return true;
-
-		case KEY_CTRLC: // hdrop  copy
-		case KEY_RCTRLC:
-			CopyFiles();
 			return true;
 
 #if 0
@@ -2405,6 +2430,7 @@ bool FileList::ProcessKey(const Manager::Key& Key)
 			return true;
 
 		case KEY_INS:          case KEY_NUMPAD0:
+		case KEY_CTRLSHIFTE:   case KEY_RCTRLSHIFTE: // alias for machines with no numeric keypad
 		{
 			if (m_ListData.empty())
 				return true;

--- a/far/filepanels.cpp
+++ b/far/filepanels.cpp
@@ -525,8 +525,21 @@ bool FilePanels::ProcessKey(const Manager::Key& Key)
 		}
 		case KEY_CTRLSHIFTS:
 		case KEY_RCTRLSHIFTS:
+		case KEY_CTRLALTS:
+		case KEY_RCTRLALTS:
+		case KEY_CTRLRALTS:
+		case KEY_RCTRLRALTS:
 		{
 			process_default = true;
+			// Remap keys for whether we use numeric pads or not
+			if (Global->Opt->NoNumericPad)
+			{
+				if (LocalKey == KEY_CTRLSHIFTS || LocalKey == KEY_RCTRLSHIFTS) break;
+			}
+			else
+			{
+				if (LocalKey == KEY_CTRLALTS || LocalKey == KEY_RCTRLALTS || LocalKey == KEY_CTRLRALTS || LocalKey == KEY_RCTRLRALTS) break;
+			}
 			if (ActivePanel()->IsVisible())
 			{
 				auto atype = ActivePanel()->GetType();

--- a/far/qview.cpp
+++ b/far/qview.cpp
@@ -345,12 +345,12 @@ bool QuickView::ProcessKey(const Manager::Key& Key)
 		return true;
 	}
 
-	if (LocalKey==KEY_ADD || LocalKey==KEY_SUBTRACT)
+	if (LocalKey==KEY_ADD || LocalKey==KEY_SUBTRACT || LocalKey == KEY_SHIFTDOWN || LocalKey==KEY_SHIFTUP)
 	{
 		const auto AnotherPanel = Parent()->GetAnotherPanel(this);
 
 		if (AnotherPanel->GetType() == panel_type::FILE_PANEL)
-			AnotherPanel->ProcessKey(Manager::Key(LocalKey==KEY_ADD?KEY_DOWN:KEY_UP));
+			AnotherPanel->ProcessKey(Manager::Key((LocalKey==KEY_ADD||LocalKey==KEY_SHIFTDOWN)?KEY_DOWN:KEY_UP));
 
 		return true;
 	}

--- a/far/vbuild.m4
+++ b/far/vbuild.m4
@@ -1,1 +1,1 @@
-m4_define(BUILD,5234)m4_dnl
+m4_define(BUILD,5235)m4_dnl

--- a/far/viewer.cpp
+++ b/far/viewer.cpp
@@ -1642,11 +1642,13 @@ bool Viewer::process_key(const Manager::Key& Key)
 		}
 		case KEY_ADD:
 		case KEY_SUBTRACT:
+		case KEY_SHIFTDOWN:
+		case KEY_SHIFTUP:
 		{
 			if (!ViewNamesList.empty())
 			{
 				string strName;
-				if (LocalKey == KEY_ADD? ViewNamesList.GetNextName(strName) : ViewNamesList.GetPrevName(strName))
+				if ((LocalKey == KEY_ADD || LocalKey == KEY_SHIFTDOWN) ? ViewNamesList.GetNextName(strName) : ViewNamesList.GetPrevName(strName))
 				{
 					SavePosition();
 					BMSavePos.Clear(); //Prepare for new file loading


### PR DESCRIPTION
Hi!

First of all, I'm new to this, so please tell me if I'm doing something wrong...

I'm requesting a pull to incorporate a few new key-mappings to FAR to make it more usable on small laptops without numeric keypads:

1. Added new key-mappings to support laptops with no numeric keypad
   Added new 'Don't use numeric keypad' option (default off) to toggle some conflicting or changed behavior
   Changed (English) help to describe changes

Thanks,
Andras Tantos