### PR TITLE
add catalog_user.xml in msi

### DIFF
--- a/misc/msi-installer/features.wxs
+++ b/misc/msi-installer/features.wxs
@@ -424,6 +424,7 @@
               <ComponentRef Id="catalog_console.xml" />
               <ComponentRef Id="catalog_rgb.xml" />
               <ComponentRef Id="catalog_text.xml" />
+              <ComponentRef Id="catalog_user.xml" />
               <Feature Id="FarColorer.Ignore.base_hrd_console" Level="1" Display="hidden" AllowAdvertise="no">
                 <ComponentRef Id="black.hrd" />
                 <ComponentRef Id="blue.hrd" />

--- a/misc/msi-installer/files.wxs
+++ b/misc/msi-installer/files.wxs
@@ -829,6 +829,9 @@
               <Component Id="catalog_text.xml" Guid="$(var.Guid.catalog_text.xml)" Win64="$(var.Win64)">
                 <File Id="catalog_text.xml" KeyPath="yes" Source="$(var.SourceDir)\Plugins\FarColorer\base\hrd\catalog-text.xml" />
               </Component>
+              <Component Id="catalog-user.xml" Guid="$(var.Guid.catalog-user.xml)" Win64="$(var.Win64)">
+                <File Id="catalog-user.xml" KeyPath="yes" Source="$(var.SourceDir)\Plugins\FarColorer\base\hrd\catalog-user.xml" />
+              </Component>
               <Directory Id="FarColorer.base.hrd.console" Name="console">
                 <Component Id="black.hrd" Guid="$(var.Guid.black.hrd)" Win64="$(var.Win64)">
                   <File Id="black.hrd" KeyPath="yes" Source="$(var.SourceDir)\Plugins\FarColorer\base\hrd\console\black.hrd" />

--- a/misc/msi-installer/guids_x64.wxi
+++ b/misc/msi-installer/guids_x64.wxi
@@ -255,6 +255,7 @@
 <?define Guid.catalog_console.xml = "7E43C2D9-6F2B-1014-81B7-D7B67EB629B5" ?>
 <?define Guid.catalog_rgb.xml = "7E43C3B1-6F2B-1014-87CD-C9D95F2BF399" ?>
 <?define Guid.catalog_text.xml = "7E43C48A-6F2B-1014-BE99-994D6F942EA5" ?>
+<?define Guid.catalog_user.xml = "93F98FBD-1E06-4D0A-AAB3-102BA77B62C8" ?>
 <?define Guid.black.hrd = "7E43C563-6F2B-1014-B1F6-849700DE49D3" ?>
 <?define Guid.blue.hrd = "7E43C63C-6F2B-1014-B7D1-F554971C0888" ?>
 <?define Guid.default.hrd = "7E43C715-6F2B-1014-90DF-D99E92AA2DA5" ?>

--- a/misc/msi-installer/guids_x86.wxi
+++ b/misc/msi-installer/guids_x86.wxi
@@ -255,6 +255,7 @@
 <?define Guid.catalog_console.xml = "95585C01-6F2B-1014-A753-80DB300C8DF9" ?>
 <?define Guid.catalog_rgb.xml = "95585CE3-6F2B-1014-ACC6-81C66B5C5743" ?>
 <?define Guid.catalog_text.xml = "95585DC5-6F2B-1014-91EB-F43568027F9D" ?>
+<?define Guid.catalog_user.xml = "80851D6D-420E-41F1-9C95-E4FED07CCD4D" ?>
 <?define Guid.black.hrd = "95585EA8-6F2B-1014-A671-D9E9BF8E714B" ?>
 <?define Guid.blue.hrd = "95585F88-6F2B-1014-AFAF-D9A3192BCCF7" ?>
 <?define Guid.default.hrd = "9558606A-6F2B-1014-8773-932C0C307D92" ?>


### PR DESCRIPTION
В новой версии схем colorer появился обязательный файл catalog_user.xml.  Добавляем его в инсталятор.