### PR TITLE
Added method for read-only edit fields to dialog builder.

### DIFF
--- a/far/DlgBuilder.hpp
+++ b/far/DlgBuilder.hpp
@@ -1072,6 +1072,15 @@ public:
 			return Item;
 		}
 
+		FarDialogItem *AddReadonlyEditField(const wchar_t *Value, int Width)
+		{
+			FarDialogItem *Item = AddDialogItem(DI_EDIT, Value);
+			SetNextY(Item);
+			Item->X2 = Item->X1 + (Width > 0 ? Width : TextWidth(*Item)) - 1;
+			Item->Flags |= DIF_READONLY;
+			return Item;
+		}
+
 		FarDialogItem *AddComboBox(int *SelectedItem, wchar_t *Text, int Width, const wchar_t* const* ItemsText, size_t ItemCount, FARDIALOGITEMFLAGS ItemFlags)
 		{
 			return AddListControl(DI_COMBOBOX, SelectedItem, Text, Width, 0, ItemsText, ItemCount, ItemFlags);


### PR DESCRIPTION
New method for FarDialogBuilder class - AddReadonlyEditField.
Currently to add read-only edit filed one has to create temporary writable buffer, copy content to it and then use AddEditField and set DIF_READONLY. New function allows to it in one call and avoid creating redundant buffer making code more cleaner