### PR TITLE
update FarColorer

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -138,7 +138,7 @@ build_script:
   - mkdir ci\%configuration%.%platform%\Plugins\FarColorer\base
   - xcopy /e /q /y /k Colorer-schemes\build\basefar\* ci\%configuration%.%platform%\Plugins\FarColorer\base
   - mkdir ci\%configuration%.%platform%\Plugins\FarColorer\bin
-  - copy /Y FarColorer\build\%configuration%\%platform%\colorer.* ci\%configuration%.%platform%\Plugins\FarColorer\bin
+  - copy /Y FarColorer\build\%configuration%\%platform%\src\colorer.* ci\%configuration%.%platform%\Plugins\FarColorer\bin
   - copy /Y FarColorer\docs\history.ru.txt ci\%configuration%.%platform%\Plugins\FarColorer
   - copy /Y FarColorer\LICENSE ci\%configuration%.%platform%\Plugins\FarColorer
   - copy /Y FarColorer\README.md ci\%configuration%.%platform%\Plugins\FarColorer

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ install:
   - build.cmd base.far
   - cd ..
   #clone FarColorer
-  - git clone https://github.com/colorer/FarColorer.git --recursive -b develop
+  - git clone https://github.com/colorer/FarColorer.git --recursive
   #set locale to russian, needed for chm generation
   - ps: Set-WinSystemLocale -SystemLocale ru-RU
   - ps: Start-Sleep -s 5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -32,7 +32,7 @@ install:
   - build.cmd base.far
   - cd ..
   #clone FarColorer
-  - git clone https://github.com/colorer/FarColorer.git --recursive
+  - git clone https://github.com/colorer/FarColorer.git --recursive -b develop
   #set locale to russian, needed for chm generation
   - ps: Set-WinSystemLocale -SystemLocale ru-RU
   - ps: Start-Sleep -s 5
@@ -132,7 +132,7 @@ build_script:
   - cd FarColorer
   - mkdir build\%configuration%\%platform%
   - cd build\%configuration%\%platform%
-  - cmake -G "NMake Makefiles" -D PROJECT_ROOT=%PROJECT_ROOT% -D CMAKE_BUILD_TYPE=%PROJECT_CONFIG% -D CONF=%PROJECT_CONF% %PROJECT_ROOT%\src
+  - cmake -G "NMake Makefiles" -D CMAKE_BUILD_TYPE=%PROJECT_CONFIG% -D CONF=%PROJECT_CONF% %PROJECT_ROOT%
   - nmake
   - cd ..\..\..\..
   - mkdir ci\%configuration%.%platform%\Plugins\FarColorer\base

--- a/misc/nightly/colorer.32.bat
+++ b/misc/nightly/colorer.32.bat
@@ -4,5 +4,5 @@ set PROJECT_ROOT=%~dp0FarColorer
 set PROJECT_CONFIG=Release
 set PROJECT_CONF=x86
 
-c:\cmake\bin\cmake.exe -G "NMake Makefiles" -D PROJECT_ROOT=%PROJECT_ROOT% -D CMAKE_BUILD_TYPE=%PROJECT_CONFIG% -D CONF=%PROJECT_CONF% %PROJECT_ROOT%\src
+c:\cmake\bin\cmake.exe -G "NMake Makefiles" -D CMAKE_BUILD_TYPE=%PROJECT_CONFIG% -D CONF=%PROJECT_CONF% %PROJECT_ROOT%
 nmake

--- a/misc/nightly/colorer.64.bat
+++ b/misc/nightly/colorer.64.bat
@@ -4,5 +4,5 @@ set PROJECT_ROOT=%~dp0FarColorer
 set PROJECT_CONFIG=Release
 set PROJECT_CONF=x64
 
-c:\cmake\bin\cmake.exe -G "NMake Makefiles" -D PROJECT_ROOT=%PROJECT_ROOT% -D CMAKE_BUILD_TYPE=%PROJECT_CONFIG% -D CONF=%PROJECT_CONF% %PROJECT_ROOT%\src
+c:\cmake\bin\cmake.exe -G "NMake Makefiles" -D CMAKE_BUILD_TYPE=%PROJECT_CONFIG% -D CONF=%PROJECT_CONF% %PROJECT_ROOT%
 nmake


### PR DESCRIPTION
new version FarColorer 1.3.0
This pull request first for check build in appveyor and in nigth build. After checking and successful build, it will be necessary to remove the brunch name 'develop' in appveyor script. 
For VS2019 all will be ok. For VS2017 you need update cmake to version 3.15.