### PR TITLE
Customization of default history key in F2 user menu input field (UserVar)

### DIFF
--- a/far/FarEng.hlf.m4
+++ b/far/FarEng.hlf.m4
@@ -2261,6 +2261,9 @@ executing command. <title> and <init> - title and initial text of edit control.
 
  Leave the name empty to disable history.
 
+ If the title field ends with a #|# the title itself is used internally as the history key for the input text (instead of #UserVarN#)
+allowing different entries in the menu to have different input text histories.
+
  The entered string can also be accessed later as #%<history># (or as #%UserVarN#, where N is the index of the corresponding input).
 
  In <title> and <init> the usage of other meta-symbols is allowed by enclosing them in brackets, e.g.

--- a/far/FarGer.hlf.m4
+++ b/far/FarGer.hlf.m4
@@ -2339,6 +2339,9 @@ $ #Special symbols#
 
  Leave the name empty to disable history.
 
+ If the title field ends with a #|# the title itself is used internally as the history key for the input text (instead of #UserVarN#)
+allowing different entries in the menu to have different input text histories.
+
  The entered string can also be accessed later as #%<history># (or as #%UserVarN#, where N is the index of the corresponding input).
 
  In <title> and <init> the usage of other meta-symbols is allowed by enclosing them in brackets, e.g.

--- a/far/FarHun.hlf.m4
+++ b/far/FarHun.hlf.m4
@@ -2339,6 +2339,9 @@ Ebben az esetben a parancssor formátuma: #!?$<előzmény>$<név>?<alapérték>!
 
  Leave the name empty to disable history.
 
+ If the title field ends with a #|# the title itself is used internally as the history key for the input text (instead of #UserVarN#)
+allowing different entries in the menu to have different input text histories.
+
  The entered string can also be accessed later as #%<history># (or as #%UserVarN#, where N is the index of the corresponding input).
 
 A <név> és az <alapérték> beírásánál más különleges szimbólumot is használhatunk, zárójelek között. Példa:

--- a/far/FarPol.hlf.m4
+++ b/far/FarPol.hlf.m4
@@ -2254,6 +2254,9 @@ executing command. <title> and <init> - title and initial text of edit control.
 
  Leave the name empty to disable history.
 
+ If the title field ends with a #|# the title itself is used internally as the history key for the input text (instead of #UserVarN#)
+allowing different entries in the menu to have different input text histories.
+
  The entered string can also be accessed later as #%<history># (or as #%UserVarN#, where N is the index of the corresponding input).
 
  In <title> and <init> the usage of other meta-symbols is allowed by enclosing them in brackets, e.g.

--- a/far/FarRus.hlf.m4
+++ b/far/FarRus.hlf.m4
@@ -2309,6 +2309,9 @@ $ #Метасимволы#
 
  Для отключения истории оставьте имя пустым.
 
+ If the title field ends with a #|# the title itself is used internally as the history key for the input text (instead of #UserVarN#)
+allowing different entries in the menu to have different input text histories.
+
  The entered string can also be accessed later as #%<history># (or as #%UserVarN#, where N is the index of the corresponding input).
 
  В <title> и <init> допускается использование прочих метасимволов, заключив их в круглые операторные скобки, например

--- a/far/FarUkr.hlf.m4
+++ b/far/FarUkr.hlf.m4
@@ -2315,6 +2315,9 @@ $ #Метасимволи#
 
  Leave the name empty to disable history.
 
+ If the title field ends with a #|# the title itself is used internally as the history key for the input text (instead of #UserVarN#)
+allowing different entries in the menu to have different input text histories.
+
  The entered string can also be accessed later as #%<history># (or as #%UserVarN#, where N is the index of the corresponding input).
 
  In <title> and <init> the usage of other meta-symbols is allowed by enclosing them in brackets, e.g.

--- a/far/changelog
+++ b/far/changelog
@@ -1,3 +1,7 @@
+yogdg 15.01.2021 19:28:00 +0000 - build 5731
+
+1. Adding of possibility to change history's default key in F2 user menu input field (UserVar).
+
 drkns 14.01.2021 17:50:34 +0000 - build 5730
 
 1. 5728 еще раз.

--- a/far/changelog_eng
+++ b/far/changelog_eng
@@ -1,3 +1,7 @@
+yogdg 15.01.2021 19:28:00 +0000 - build 5731
+
+1. Customization of default history key in F2 user menu input field (UserVar).
+
 drkns 14.01.2021 17:50:34 +0000 - build 5730
 
 1. 5728 once again.

--- a/far/fnparce.cpp
+++ b/far/fnparce.cpp
@@ -681,9 +681,9 @@ static bool InputVariablesDialog(string& strStr, subst_data& SubstData, string_v
 
 	constexpr auto HistoryAndVariablePrefix = L"UserVar"sv;
 
-	const auto GenerateHistoryName = [&](size_t const Index)
+	const auto GenerateHistoryName = [&](size_t const Index, const string_view customPrefix = {})
 	{
-		return format(FSTR(L"{0}{1}"), HistoryAndVariablePrefix, Index);
+		return format(FSTR(L"{0}{1}"), customPrefix.empty() ? HistoryAndVariablePrefix : customPrefix, Index);
 	};
 
 	constexpr auto ExpectedTokensCount = 64;
@@ -744,7 +744,13 @@ static bool InputVariablesDialog(string& strStr, subst_data& SubstData, string_v
 			Item.X2 = DlgWidth - 6;
 			Item.Y1 = Item.Y2 = DlgData.size() + 1;
 			Item.Flags = DIF_HISTORY | DIF_USELASTHISTORY;
-			Item.strHistory = GenerateHistoryName((DlgData.size() - 1) / 2);
+			if(Strings.Title.All.back() != L'|')
+				Item.strHistory = GenerateHistoryName((DlgData.size() - 1) / 2);
+			else
+			{
+				Strings.Title.All.remove_suffix(1);
+				Item.strHistory = GenerateHistoryName((DlgData.size() - 1) / 2, Strings.Title.All);
+			}
 			DlgData.emplace_back(Item);
 		}
 


### PR DESCRIPTION
The idea is to be able to replace the default history key used while inputting text in the user menu with one provided by the end user. This PR will allow Far to save the input text by a different key, provided the title ends with a *|*. So, for example, an input field (o serveral ones) can have its own private history without altering the rest of the input fields defined in the user menu.