### PR TITLE
Add GitHub actions workflow

### DIFF
--- a/.github/workflows/far-build.yml
+++ b/.github/workflows/far-build.yml
@@ -1,0 +1,50 @@
+name: Far build checks
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: windows-2019
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler: [ MSVC_PROJ, MSVC_NMAKE ]
+        arch: [ x64, Win32 ]
+        build_config: [ Debug, Release ]
+
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+
+      - name: Set MSVC envrioment
+        uses: ilammy/msvc-dev-cmd@v1.6.0
+        with:
+          arch: ${{ matrix.arch }}
+
+      - name: Build MsBuild
+        if: ${{ matrix.compiler }} == 'MSVC_PROJ'
+        working-directory: ${{runner.workspace}}/far
+        run: MSBuild.exe /property:Configuration=${{ matrix.build_config }} /property:Platform=${{ matrix.arch }} far.vcxproj
+
+      - name: Build NMake Far
+        if: ${{ matrix.compiler }} == 'MSVC_NMAKE'
+        working-directory: ${{runner.workspace}}/far
+        run: |
+          if ${{ matrix.build_config }}==Debug set DEBUG=1
+          nmake /f makefile_vc
+
+      - name: Build NMake Plugins
+        if: ${{ matrix.compiler }} == 'MSVC_NMAKE'
+        working-directory: ${{runner.workspace}}/plugins
+        run: |
+          if ${{ matrix.build_config }}==Debug set DEBUG=1
+          nmake /f makefile_vc
+
+
+      
+    

--- a/.github/workflows/far-build.yml
+++ b/.github/workflows/far-build.yml
@@ -13,38 +13,107 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [ MSVC_PROJ, MSVC_NMAKE ]
-        arch: [ x64, Win32 ]
-        build_config: [ Debug, Release ]
+        build: [ MSVC_PROJ_x64_Debug,MSVC_PROJ_x64_Release,MSVC_PROJ_x86_Debug,MSVC_PROJ_x86_Release,
+                 MSVC_NMAKE_x64_Debug, MSVC_NMAKE_x64_Release,MSVC_NMAKE_x86_Debug,MSVC_NMAKE_x86_Release,
+                 CLANG_NMAKE_x64_Debug,CLANG_NMAKE_x64_Release,
+                 GCC_MAKE_x64_Debug,GCC_MAKE_x64_Release,
+                 CLANG_MAKE_x64_Debug,CLANG_MAKE_x64_Release ]
+        include:
+          - { build: MSVC_PROJ_x64_Debug, compiler: MSVC_PROJ, arch: x64, build_config: Debug }
+          - { build: MSVC_PROJ_x64_Release, compiler: MSVC_PROJ, arch: x64, build_config: Release }
+          - { build: MSVC_PROJ_x86_Debug, compiler: MSVC_PROJ, arch: Win32, build_config: Debug }
+          - { build: MSVC_PROJ_x86_Release, compiler: MSVC_PROJ, arch: Win32, build_config: Release }
+          - { build: MSVC_NMAKE_x64_Debug, compiler: MSVC_NMAKE, arch: x64, build_config: Debug }
+          - { build: MSVC_NMAKE_x64_Release, compiler: MSVC_NMAKE, arch: x64, build_config: Release }
+          - { build: MSVC_NMAKE_x86_Debug, compiler: MSVC_NMAKE, arch: Win32, build_config: Debug }
+          - { build: MSVC_NMAKE_x86_Release, compiler: MSVC_NMAKE, arch: Win32, build_config: Release }
+          - { build: CLANG_NMAKE_x64_Debug, compiler: CLANG_NMAKE, arch: x64, build_config: Debug }
+          - { build: CLANG_NMAKE_x64_Release, compiler: CLANG_NMAKE, arch: x64, build_config: Release }
+          - { build: GCC_MAKE_x64_Debug, compiler: GCC_MAKE, arch: x64, build_config: Debug }
+          - { build: GCC_MAKE_x64_Release, compiler: GCC_MAKE, arch: x64, build_config: Release }
+          - { build: CLANG_MAKE_x64_Debug, compiler: CLANG_MAKE, arch: x64, build_config: Debug }
+          - { build: CLANG_MAKE_x64_Release, compiler: CLANG_MAKE, arch: x64, build_config: Release }
 
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
 
       - name: Set MSVC envrioment
+        if: matrix.compiler == 'MSVC_PROJ' || matrix.compiler == 'MSVC_NMAKE' || matrix.compiler == 'CLANG_NMAKE'
         uses: ilammy/msvc-dev-cmd@v1.6.0
         with:
           arch: ${{ matrix.arch }}
 
+      - name: Set envirement for debug build
+        if: matrix.build_config  == 'Debug'
+        run: set DEBUG=1
+
       - name: Build MsBuild
-        if: ${{ matrix.compiler }} == 'MSVC_PROJ'
-        working-directory: ${{runner.workspace}}/far
+        if: matrix.compiler == 'MSVC_PROJ'
+        working-directory: ${{runner.workspace}}/FarManager/far
         run: MSBuild.exe /property:Configuration=${{ matrix.build_config }} /property:Platform=${{ matrix.arch }} far.vcxproj
 
       - name: Build NMake Far
-        if: ${{ matrix.compiler }} == 'MSVC_NMAKE'
-        working-directory: ${{runner.workspace}}/far
+        if: matrix.compiler  == 'MSVC_NMAKE'
+        working-directory: ${{runner.workspace}}/FarManager/far
         run: |
-          if ${{ matrix.build_config }}==Debug set DEBUG=1
-          nmake /f makefile_vc
+          cl.exe
+          nmake /f makefile_vc ${{ matrix.add_make }}
 
       - name: Build NMake Plugins
-        if: ${{ matrix.compiler }} == 'MSVC_NMAKE'
-        working-directory: ${{runner.workspace}}/plugins
+        if: matrix.compiler  == 'MSVC_NMAKE'
+        working-directory: ${{runner.workspace}}/FarManager/plugins
+        run: nmake /f makefile_all_vc
+
+      - name: Build Clang NMake Far
+        if: matrix.compiler  == 'CLANG_NMAKE'
+        working-directory: ${{runner.workspace}}/FarManager/far
         run: |
-          if ${{ matrix.build_config }}==Debug set DEBUG=1
-          nmake /f makefile_vc
+          clang --version
+          nmake /f makefile_vc CLANG=1
 
+      - name: Install Mingw GCC x64
+        if: matrix.compiler  == 'GCC_MAKE'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          install: make gcc mingw-w64-x86_64-crt
 
-      
-    
+      - name: Build Mingw GCC Far
+        if: matrix.compiler  == 'GCC_MAKE'
+        working-directory: ${{runner.workspace}}/FarManager/far
+        shell: msys2 {0}
+        run: |
+          gcc --version
+          make -j4 -f makefile_gcc ${{ matrix.add_make }}
+
+      - name: Build Mingw GCC Plugins
+        if: matrix.compiler  == 'GCC_MAKE'
+        working-directory: ${{runner.workspace}}/FarManager/plugins
+        shell: msys2 {0}
+        run: |
+          gcc --version
+          make -j4 -f makefile_all_gcc
+
+      - name: Install Mingw Clang x64
+        if: matrix.compiler  == 'CLANG_MAKE'
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          install: make mingw-w64-x86_64-clang mingw-w64-x86_64-crt
+
+      - name: Build Mingw Clang Far
+        if: matrix.compiler  == 'CLANG_MAKE'
+        working-directory: ${{runner.workspace}}/FarManager/far
+        shell: msys2 {0}
+        run: |
+          clang --version
+          make -j4 CLANG=1 -f makefile_gcc
+
+      - name: Build Mingw Clang Plugins
+        if: matrix.compiler  == 'CLANG_MAKE'
+        working-directory: ${{runner.workspace}}/FarManager/plugins
+        shell: msys2 {0}
+        run: |
+          clang --version
+          make -j4 CLANG=1 -f makefile_all_gcc

--- a/.github/workflows/far-build.yml
+++ b/.github/workflows/far-build.yml
@@ -58,7 +58,7 @@ jobs:
         working-directory: ${{runner.workspace}}/FarManager/far
         run: |
           cl.exe
-          nmake /f makefile_vc ${{ matrix.add_make }}
+          nmake /f makefile_vc
 
       - name: Build NMake Plugins
         if: matrix.compiler  == 'MSVC_NMAKE'
@@ -85,7 +85,7 @@ jobs:
         shell: msys2 {0}
         run: |
           gcc --version
-          make -j4 -f makefile_gcc ${{ matrix.add_make }}
+          make -j4 -f makefile_gcc
 
       - name: Build Mingw GCC Plugins
         if: matrix.compiler  == 'GCC_MAKE'


### PR DESCRIPTION
Добавил workflow проверки commit/pull request по аналогии с travis.
Пока это пример, чтобы увидеть возможности.
Собирает все те же конфигурации (или пытается собрать).

Вот https://github.com/ctapmex/FarManager/actions/runs/658688039 результаты прогона именно этой версии скрипта на v3.0.5761 .
Для gcc и clang устанавливается MSYS2, в котором обычно последние версии. И как видишь, оно падает. Сейчас уже нет сил разбираться в чем дело. Но когда использовался предустановленный msys2  сборка на gcc проходила (https://github.com/ctapmex/FarManager/actions/runs/658608843 смотреть только gcc)

варианты оптимизации/изменения скрипта 
1. надо ли тестировать все эти комбинации debug/release/platform ?
2. можно задать другие версии gcc/clang
3. в таком виде статус сборки будет показываться целиком без разбивки на компиляторы. Если надо выводить в readme.md статус с разбивкой на компиляторы, то workflow надо разбивать на несколько файлов
4. можно сгруппировать действия по компиляторам, чтобы в логах выполнения не было пропущенных шагов