### PR TITLE
Encyclopedia building workflow

### DIFF
--- a/.github/workflows/docs-pages.yml
+++ b/.github/workflows/docs-pages.yml
@@ -1,0 +1,31 @@
+name: Docs Pages
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build Enc
+        run: ./enc/tools/tool.make_inet.py
+
+      - name: GitHub Pages
+        if: success()
+        uses: crazy-max/ghaction-github-pages@v2.3.0
+        with:
+          repo: FarGroup/api
+          target_branch: master
+          keep_history: true
+          # Build directory to deploy
+          build_dir: enc/build/inet
+          # Write the given domain name to the CNAME file
+          #fqdn: # optional
+          # Allow Jekyll to build your site
+          jekyll: false
+        env:
+          GH_PAT: ${{ secrets.GH_PAT }}

--- a/enc/tools/tool.make_inet.py
+++ b/enc/tools/tool.make_inet.py
@@ -1,4 +1,4 @@
-﻿#!/usr/bin/env python3
+#!/usr/bin/env python3
 
 """
 Make web suitable Encyclopedia
@@ -85,14 +85,14 @@ def make_inet_lang(lang):
 
 
 log("preparing INET build")
-log("-- cleaning build dir")
+log("-- cleaning build dir " + DEST)
 if isdir(DEST): shutil.rmtree(DEST)
 makedirs(DEST)
 logfile = logging.FileHandler(BUILD_INET_LOG, "w", encoding="utf-8")
 logging.getLogger().addHandler(logfile)
 
 
-log("-- making directory tree")
+log("-- output dir " + DEST_INET)
 makedirs(DEST_INET)
 makedirs(join(DEST_INET,"images"))
 makedirs(join(DEST_INET,"styles"))
@@ -101,8 +101,8 @@ make_inet_lang("rus")
 #make_inet_lang("eng")
 
 log("-- copying index files")
-shutil.copy("inet/index.html", DEST_INET)
-shutil.copy("inet/farenclogo.gif", join(DEST_INET,"images"))
-shutil.copy("inet/styles.css", join(DEST_INET,"styles"))
+shutil.copy(ROOT_DIR+"/tools/inet/index.html", DEST_INET)
+shutil.copy(ROOT_DIR+"/tools/inet/farenclogo.gif", join(DEST_INET,"images"))
+shutil.copy(ROOT_DIR+"/tools/inet/styles.css", join(DEST_INET,"styles"))
 
 log("-- done. check build log at %s" % BUILD_INET_LOG)


### PR DESCRIPTION
This will publish current version of encyclopedia into `enc` branch which will be available then at https://FarGroup.github.io/FarManager/

This also includes two commits that were sitting in my fork for few years. It looks like they are harmless, and I don't have HHC to debug them. If the PR is merged, it will be possible to use GitHub CI for the testing.