### PR TITLE
wrong order of version elements

### DIFF
--- a/far/mix.cpp
+++ b/far/mix.cpp
@@ -363,7 +363,7 @@ string version_to_string(const VersionInfo& Version)
 
 	static_assert(std::size(Stage) == VS_PRIVATE + 1);
 
-	auto VersionStr = format(FSTR(L"{}.{}.{}.{}"sv), Version.Major, Version.Minor, Version.Build, Version.Revision);
+	auto VersionStr = format(FSTR(L"{}.{}.{}.{}"sv), Version.Major, Version.Minor, Version.Revision, Version.Build);
 	if (Version.Stage != VS_RELEASE && static_cast<size_t>(Version.Stage) < std::size(Stage))
 	{
 		append(VersionStr, L" ("sv, Stage[Version.Stage], L')');


### PR DESCRIPTION
Wrong order of version elements. Dispaled in F9 - Options - Plugins configuration
