### PR TITLE
LuaFAR: fix DM_GETDLGDATA / DM_SETDLGDATA.

### DIFF
--- a/enc/enc_lua/luafar_manual.tsi
+++ b/enc/enc_lua/luafar_manual.tsi
@@ -3152,7 +3152,7 @@ id=71
 lv=2
 dt=Text
 nm=far.SendDlgMessage
-mtime=3746038169
+mtime=3835879532
 <article>
 #_Result = far.SendDlgMessage (hDlg, Msg, Param1, Param2)
 #_    or
@@ -3175,7 +3175,6 @@ mtime=3746038169
 #_DM_ENABLEREDRAW,
 #_DM_GETCHECK,
 #_DM_GETCURSORSIZE,
-#_DM_GETDLGDATA,
 #_DM_GETDROPDOWNOPENED,
 #_DM_GETFOCUS,
 #_DM_GETITEMDATA,
@@ -3184,7 +3183,6 @@ mtime=3746038169
 #_DM_REDRAW,
 #_DM_SET3STATE,
 #_DM_SETCURSORSIZE,
-#_DM_SETDLGDATA,
 #_DM_SETDROPDOWNOPENED,
 #_DM_SETFOCUS,
 #_DM_SETINPUTNOTIFY,
@@ -3364,13 +3362,18 @@ mtime=3746038169
 #_DN_DRAGGED,
 #_DN_DRAWDIALOG,
 #_DN_DRAWDIALOGDONE,
-#_DN_DROPDOWNOPENED,
+#_DN_DROPDOWNOPENED:
 #_    Param2:  integer
 #_    Result:  integer
 #_
 #_DN_CONTROLINPUT:
 #_    Param2:  `tInputRecord` or string
 #_    Result:  integer
+#_
+#_DM_GETDLGDATA,
+#_DM_SETDLGDATA:
+#_  These operations are not implemented as they are used internally by LuaFAR.
+#_  Param1 and Param2 are ignored; nil is returned.
 #_
 #_**Far API used:**
 #_  SendDlgMessage

--- a/plugins/luamacro/_globalinfo.lua
+++ b/plugins/luamacro/_globalinfo.lua
@@ -1,6 +1,6 @@
 function export.GetGlobalInfo()
   return {
-    Version       = { 3, 0, 0, 763 },
+    Version       = { 3, 0, 0, 764 },
     MinFarVersion = { 3, 0, 0, 5171 },
     Guid          = win.Uuid("4EBBEFC8-2084-4B7F-94C0-692CE136894D"),
     Title         = "LuaMacro",

--- a/plugins/luamacro/changelog
+++ b/plugins/luamacro/changelog
@@ -1,3 +1,8 @@
+johnd0e 20.07.2021 12:00:00 +0200 - build 764
+
+1. LuaFAR: DM_GETDLGDATA / DM_SETDLGDATA are "no-ops" now: ignore parameters and return nil.
+   (patch from shmuel).
+
 johnd0e 30.04.2021 12:17:00 +0200 - build 763
 
 1. LuaFAR: fix file:seek() for files larger than 2 GB

--- a/plugins/luamacro/luafar/service.c
+++ b/plugins/luamacro/luafar/service.c
@@ -3041,6 +3041,10 @@ static int far_SendDlgMessage(lua_State *L)
 	Msg = CAST(int, check_env_flag(L, 2));
 	lua_settop(L, 4);
 
+	// Special cases (implemented as no-ops as these message types are used internally)
+	if (Msg == DM_GETDLGDATA || Msg == DM_SETDLGDATA)
+		return lua_pushnil(L), 1;
+
 	// Param1
 	switch(Msg)
 	{
@@ -3051,7 +3055,6 @@ static int far_SendDlgMessage(lua_State *L)
 		case DM_ENABLEREDRAW:
 		case DM_GETDIALOGINFO:
 		case DM_GETDIALOGTITLE:
-		case DM_GETDLGDATA:
 		case DM_GETDLGRECT:
 		case DM_GETDROPDOWNOPENED:
 		case DM_GETFOCUS:
@@ -3059,7 +3062,6 @@ static int far_SendDlgMessage(lua_State *L)
 		case DM_MOVEDIALOG:
 		case DM_REDRAW:
 		case DM_RESIZEDIALOG:
-		case DM_SETDLGDATA:
 		case DM_SETINPUTNOTIFY:
 		case DM_SHOWDIALOG:
 		case DM_USER:
@@ -3098,7 +3100,6 @@ static int far_SendDlgMessage(lua_State *L)
 		case DM_GETCHECK:
 		case DM_GETCOMBOBOXEVENT:
 		case DM_GETCURSORSIZE:
-		case DM_GETDLGDATA:
 		case DM_GETDROPDOWNOPENED:
 		case DM_GETFOCUS:
 		case DM_GETITEMDATA:
@@ -3106,7 +3107,6 @@ static int far_SendDlgMessage(lua_State *L)
 		case DM_REDRAW:               // alias: DM_SETREDRAW
 		case DM_SET3STATE:
 		case DM_SETCURSORSIZE:
-		case DM_SETDLGDATA:
 		case DM_SETDROPDOWNOPENED:
 		case DM_SETFOCUS:
 		case DM_SETITEMDATA:

--- a/plugins/luamacro/luafar/version.h
+++ b/plugins/luamacro/luafar/version.h
@@ -1,3 +1,3 @@
 #include <farversion.hpp>
 
-#define PLUGIN_BUILD 763
+#define PLUGIN_BUILD 764


### PR DESCRIPTION
(patch from shmuel https://forum.farmanager.com/viewtopic.php?p=167528#p167528).

- Prevents crashes when using DM_SETDLGDATA.
- Makes the behavior of DM_GETDLGDATA and DM_SETDLGDATA deterministic -
  "no-ops", ignore parameters and return nil.
- Aligns the manual with the above.

History of the issue: https://forum.ru-board.com/topic.cgi?forum=5&topic=50439&start=2860#5