### PR TITLE
LuaMacro: remove unnecessary metatables access restrictions..

### DIFF
--- a/plugins/luamacro/_globalinfo.lua
+++ b/plugins/luamacro/_globalinfo.lua
@@ -1,6 +1,6 @@
 function export.GetGlobalInfo()
   return {
-    Version       = { 3, 0, 0, 764 },
+    Version       = { 3, 0, 0, 765 },
     MinFarVersion = { 3, 0, 0, 5171 },
     Guid          = win.Uuid("4EBBEFC8-2084-4B7F-94C0-692CE136894D"),
     Title         = "LuaMacro",

--- a/plugins/luamacro/api.lua
+++ b/plugins/luamacro/api.lua
@@ -10,7 +10,7 @@ local band,bor = bit64.band,bit64.bor
 local MacroCallFar = Shared.MacroCallFar
 
 local function SetProperties (namespace, proptable)
-  local meta = { __metatable="access denied", __newindex=function() end }
+  local meta = {}
   meta.__index = function(tb,nm)
     local f = proptable[nm]
     if f then return f() end

--- a/plugins/luamacro/changelog
+++ b/plugins/luamacro/changelog
@@ -1,3 +1,9 @@
+johnd0e 06.09.2021 12:00:00 +0200 - build 765
+
+1. Remove unnecessary metatables access restrictions when creating global 
+   MacroAPI tables (Area, Editor, etc.)
+   (patch from shmuel).
+
 johnd0e 20.07.2021 12:00:00 +0200 - build 764
 
 1. LuaFAR: DM_GETDLGDATA / DM_SETDLGDATA are "no-ops" now: ignore parameters and return nil.

--- a/plugins/luamacro/luafar/version.h
+++ b/plugins/luamacro/luafar/version.h
@@ -1,3 +1,3 @@
 #include <farversion.hpp>
 
-#define PLUGIN_BUILD 764
+#define PLUGIN_BUILD 765


### PR DESCRIPTION
..when creating global MacroAPI tables (Area, Editor, etc.)

patch from @shmuz.

https://forum.farmanager.com/viewtopic.php?p=168362#p168362