### PR TITLE
Update Edit.OpenURL.lua

### DIFF
--- a/extra/Addons/Macros/Edit.OpenURL.lua
+++ b/extra/Addons/Macros/Edit.OpenURL.lua
@@ -4,6 +4,11 @@
 -- Confirm launching the URL under cursor. Change it to false if you want no confirmations.
 local Confirm = true
 
+-- Change this to true to use selection (if present)
+-- instead of a fragment matching the pattern as the target URL.
+-- WARNING: setting this to true may be unsafe if you select and open a random code instead of an URL.
+local UseSelection = false
+
 local patt = regex.new( [=[
 (?:
   (?<=  [`()[\]{}‘’‚‛‹›“”„‟«»"'<>]) (?: \b \i[\d\i+.-]*: | \\ | \b www)
@@ -35,24 +40,28 @@ Macro {
     if mouseClick then
       Editor.Pos(1, 3, Editor.Pos(0, 5)+Mouse.X)
       Editor.Pos(1, 1, Editor.Pos(0, 4)+Mouse.Y-minY)
-   end
-    local s=editor.GetStringW()
-    if not s then return end
-    local pos = editor.GetInfo().CurPos
-    if pos > s.StringLength+1 then return end
-    if pos == s.StringLength+1 then pos = pos-1 end
-    local text, start = s.StringText.."\0", 1
-    while true do
-      local b,e = patt:findW(text,start)
-      if b == nil or b > pos then break end
-      if e >= pos then
-        local url = win.Utf16ToUtf8(win.subW(text,b,e))
-        if not Confirm or 1==far.Message(url, "Do you want to run this?", ";YesNo") then
-          win.ShellExecute(nil, "open", url)
+    end
+    local pos,url = editor.GetInfo().CurPos
+    if UseSelection and Editor.Sel(0,4)==1 and Editor.Sel(0,0)==Editor.Sel(0,2) and pos>=Editor.Sel(0,1) and pos<=Editor.Sel(0,3) then
+      url = Editor.SelValue
+    else
+      local s=editor.GetStringW()
+      if not s then return end
+      if pos > s.StringLength+1 then return end
+      if pos == s.StringLength+1 then pos = pos-1 end
+      local text, start = s.StringText.."\0", 1
+      while true do
+        local b,e = patt:findW(text,start)
+        if b == nil or b > pos then break end
+        if e >= pos then
+          url = win.Utf16ToUtf8(win.subW(text,b,e))
+          break
         end
-        break
+        start = e + 1
       end
-      start = e+1
+    end
+    if url and (not Confirm or 1==far.Message(url, "Do you want to run this?", ";YesNo")) then
+      win.ShellExecute(nil, "open", url)
     end
   end;
 }


### PR DESCRIPTION
<!-- Thank you for contributing! Please follow the steps below -->

<!-- Enter a brief description of your PR here -->
## Summary

If the link contains spaces, the macros catches only part of the link. Generally, it is not possible to catch all types of links correctly in principle. This change allows users to select the desired fragment so that the macros interpret the selection as a link if the pattern-based approach doesn't work sometimes.

<!-- If this PR is relevant to any other issues or existing PRs, link them here --> 
## References

<!-- Please review the items on the PR checklist before submitting -->
## Checklist
- [x] I have followed the [contributing guidelines](https://github.com/FarGroup/FarManager/blob/master/CONTRIBUTING.md).
- [ ] I have discussed this with project maintainers: <!-- add a link to the corresponding issue / discussion / forum topic here --> <br/>
If not checked, I accept that this work might be rejected in favor of a different grand plan.<br/>

<!-- Enter a more detailed description of the PR and any additional comments here -->
## Details
