### PR TITLE
Fix F8 delete on subst  drive, issue fixed #88

### DIFF
--- a/far/delete.cpp
+++ b/far/delete.cpp
@@ -975,7 +975,8 @@ static void break_links_for_old_os(string_view const Name)
 bool ShellDelete::RemoveToRecycleBin(string_view const Name, bool dir, bool& RetryRecycleAsRemove, bool& Skip)
 {
 	RetryRecycleAsRemove = false;
-	const auto strFullName = ConvertNameToFull(Name);
+	const auto strFullName = ConvertNameToReal(Name); // Real: Subst-диск заменен на оригинальный
+    // ConvertNameToFull(Name) оставляет subst (если был) и удаление будет безвозвратным
 
 	break_links_for_old_os(strFullName);
 


### PR DESCRIPTION
<!-- Thank you for contributing! Please follow the steps below -->

<!-- Enter a brief description of your PR here -->
## Summary
Attempt to delete file/folder (F8) with option DeleteToRecycleBin is On removes without moving to RecycleBin in case when we are on subst drive.
<!-- If this PR is relevant to any other issues or existing PRs, link them here --> 
## References
Reported by me in Github/FarGroup/FarManager Issue # 88 while ago
<!-- Please review the items on the PR checklist before submitting -->
## Checklist
+ [y ] I have followed the [contributing guidelines](https://github.com/FarGroup/FarManager/blob/master/CONTRIBUTING.md).
+ [ y] I have discussed this with project maintainers: https://forum.farmanager.com/viewtopic.php?t=11531
If not checked, I accept that this work might be rejected in favor of a different grand plan.<br/>

<!-- Enter a more detailed description of the PR and any additional comments here -->
## Details
