### PR TITLE
Borland paste fix

### DIFF
--- a/far/clipboard.cpp
+++ b/far/clipboard.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 clipboard.cpp
 
 Работа с буфером обмена.
@@ -59,627 +59,626 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 void default_clipboard_mode::set(clipboard_mode Mode) noexcept
 {
-  m_Mode = Mode;
+	m_Mode = Mode;
 }
 
 clipboard_mode default_clipboard_mode::get() noexcept
 {
-  return m_Mode;
+	return m_Mode;
 }
 
 //-----------------------------------------------------------------------------
 enum class clipboard_format
 {
-  vertical_block_oem,
-  vertical_block_unicode,
-  preferred_drop_effect,
-  ms_dev_column_select,
-  borland_ide_dev_block,
-  notepad_plusplus_binary_text_length,
+	vertical_block_oem,
+	vertical_block_unicode,
+	preferred_drop_effect,
+	ms_dev_column_select,
+	borland_ide_dev_block,
+	notepad_plusplus_binary_text_length,
 
-  count
+	count
 };
 
 //-----------------------------------------------------------------------------
 class system_clipboard final: public clipboard, public singleton<system_clipboard>
 {
-  IMPLEMENTS_SINGLETON;
+	IMPLEMENTS_SINGLETON;
 
 public:
-  ~system_clipboard() override
-  {
-    system_clipboard::Close();
-  }
-
-  bool Open() override
-  {
-    assert(!m_Opened);
-
-    if (m_Opened)
-      return false;
-
-    // Clipboard is a shared resource
-    const size_t Attempts = 5;
-
-    for (const auto& i: irange(Attempts))
-    {
-      // TODO: this is bad, we should use a real window handle
-      if (OpenClipboard(console.GetWindow()))
-      {
-        m_Opened = true;
-        return true;
-      }
-
-      const auto Error = last_error();
-
-      if (Error.Win32Error == ERROR_ACCESS_DENIED)
-      {
-        if (const auto Window = GetOpenClipboardWindow())
-        {
-          DWORD Pid;
-          if (const auto ThreadId = GetWindowThreadProcessId(Window, &Pid))
-          {
-            LOGWARNING(L"Clipboard is locked by {} (PID {}, TID {})"sv, os::process::get_process_name(Pid), Pid, ThreadId);
-          }
-        }
-      }
-
-      LOGDEBUG(L"OpenClipboard(): {}"sv, Error);
-
-      os::chrono::sleep_for((i + 1) * 50ms);
-    }
-
-    LOGERROR(L"OpenClipboard(): {}"sv, last_error());
-    return false;
-  }
-
-  bool Close() noexcept override
-  {
-    // Closing already closed buffer is OK
-    if (!m_Opened)
-      return true;
-
-    if (!CloseClipboard())
-    {
-      LOGERROR(L"CloseClipboard(): {}"sv, last_error());
-      return false;
-    }
-
-    m_Opened = false;
-    return true;
-  }
-
-  bool Clear() override
-  {
-    assert(m_Opened);
-
-    if (!EmptyClipboard())
-    {
-      LOGERROR(L"EmptyClipboard(): {}"sv, last_error());
-      return false;
-    }
-
-    return true;
-  }
-
-  bool SetText(const string_view Str) override
-  {
-    if (!Clear())
-      return false;
-
-    auto hData = os::memory::global::copy(Str);
-    if (!hData)
-    {
-      LOGERROR(L"global::copy(): {}"sv, last_error());
-      return false;
-    }
-
-    if (!SetData(CF_UNICODETEXT, std::move(hData)))
-      return false;
-
-    // 'Notepad++ binary text length'
-    // return value is ignored - non-critical feature
-    if (const auto Format = RegisterFormat(clipboard_format::notepad_plusplus_binary_text_length))
-    {
-      if (auto Size = os::memory::global::copy(static_cast<uint32_t>(Str.size())))
-        SetData(Format, std::move(Size));
-      else
-        LOGWARNING(L"global::copy(): {}"sv, last_error());
-    }
-
-    // return value is ignored - non-critical feature
-    if (auto Locale = os::memory::global::copy(GetUserDefaultLCID()))
-      SetData(CF_LOCALE, std::move(Locale));
-    else
-      LOGWARNING(L"global::copy(): {}"sv, last_error());
-
-    return true;
-  }
-
-  bool SetVText(const string_view Str) override
-  {
-    if (!SetText(Str))
-      return false;
-
-    const auto FarVerticalBlock = RegisterFormat(clipboard_format::vertical_block_unicode);
-    if (!FarVerticalBlock)
-      return false;
-
-    if (!SetData(FarVerticalBlock, os::memory::global::copy(0)))
-      return false;
-
-    // 'Borland IDE Block Type'
-    // return value is ignored - non-critical feature
-    if (const auto Format = RegisterFormat(clipboard_format::borland_ide_dev_block))
-      SetData(Format, os::memory::global::copy('\2'));
-
-    // 'MSDEVColumnSelect'
-    // return value is ignored - non-critical feature
-    if (const auto Format = RegisterFormat(clipboard_format::ms_dev_column_select))
-      SetData(Format, os::memory::global::copy(0));
-
-    return true;
-  }
-
-  bool SetHDROP(const string_view NamesData, const bool Move) override
-  {
-    if (NamesData.empty())
-      return false;
-
-    auto Memory = os::memory::global::alloc(GMEM_MOVEABLE, sizeof(DROPFILES) + (NamesData.size() + 1) * sizeof(wchar_t));
-    if (!Memory)
-    {
-      LOGERROR(L"global::alloc(): {}"sv, last_error());
-      return false;
-    }
-
-    const auto Drop = os::memory::global::lock<LPDROPFILES>(Memory);
-    if (!Drop)
-    {
-      LOGERROR(L"global::lock(): {}"sv, last_error());
-      return false;
-    }
-
-    Drop->pFiles = static_cast<DWORD>(aligned_sizeof<DROPFILES, sizeof(wchar_t)>);
-    Drop->pt.x = 0;
-    Drop->pt.y = 0;
-    Drop->fNC = TRUE;
-    Drop->fWide = TRUE;
-    const auto NamesPtr = edit_as<wchar_t*>(Drop.get(), Drop->pFiles);
-    assert(is_aligned(*NamesPtr));
-    *copy_string(NamesData, NamesPtr) = {};
-
-    if (!Clear() || !SetData(CF_HDROP, std::move(Memory)))
-      return false;
-
-    auto DropEffect = os::memory::global::copy<DWORD>(Move? DROPEFFECT_MOVE : DROPEFFECT_COPY);
-    if (!DropEffect)
-    {
-      LOGERROR(L"global::copy(): {}"sv, last_error());
-      return false;
-    }
-
-    const auto Format = RegisterFormat(clipboard_format::preferred_drop_effect);
-    if (!Format)
-      return false;
-
-    return SetData(Format, std::move(DropEffect));
-  }
-
-  bool GetText(string& Data) const override
-  {
-    //Check if clipboard has text in old borland format
-    const auto IsOldBorlandText = [] {
-     const auto BlockFormat = RegisterFormat(clipboard_format::borland_ide_dev_block);
-     if (!BlockFormat || !IsFormatAvailable(BlockFormat))
-       return false;
-
-     const auto BlockHandle = GetClipboardData(BlockFormat);
-     return BlockHandle && GlobalSize(BlockHandle) > 0;
-    };
-
-    if (!IsFormatAvailable(CF_UNICODETEXT))
-      return GetHDROPAsText(Data);
-
-    const auto DataHandle = GetClipboardData(CF_UNICODETEXT);
-    if (!DataHandle)
-    {
-      LOGERROR(L"GetClipboardData: {}"sv, last_error());
-      return false;
-    }
-
-    const auto DataPtr = os::memory::global::lock<const wchar_t*>(DataHandle);
-    if (!DataPtr)
-    {
-      LOGERROR(L"global::lock(): {}"sv, last_error());
-      return false;
-    }
-
-    const string_view DataView(DataPtr.get(), GlobalSize(DataHandle) / sizeof(*DataPtr));
-    if (DataView.empty())
-    {
-      LOGERROR(L"Insufficient data"sv);
-      return false;
-    }
-
-    const auto GetBinaryTextLength = []() -> std::optional<size_t>
-    {
-      const auto SizeFormat = RegisterFormat(clipboard_format::notepad_plusplus_binary_text_length);
-      if (!SizeFormat)
-        return {};
-
-      if (!IsFormatAvailable(SizeFormat))
-        return {};
-
-      const auto SizeHandle = GetClipboardData(SizeFormat);
-      if (!SizeHandle)
-      {
-        LOGWARNING(L"GetClipboardData(): {}"sv, last_error());
-        return {};
-      }
-
-      const auto SizePtr = os::memory::global::lock<const uint32_t*>(SizeHandle);
-      if (!SizePtr)
-      {
-        LOGWARNING(L"global::lock(): {}"sv, last_error());
-        return {};
-      }
-
-      const auto Size = view_as_opt<uint32_t>(SizePtr.get(), GlobalSize(SizeHandle));
-      if (!Size)
-      {
-        LOGWARNING(L"Insufficient data"sv);
-        return {};
-      }
-
-      return *Size;
-    };
-
-    const auto GetTextLength = [&]
-    {
-      if (const auto Length = GetBinaryTextLength())
-        return *Length;
-
-      return static_cast<size_t>(std::find(ALL_CONST_RANGE(DataView), L'\0') - DataView.cbegin());
-    };
-
-    Data = DataView.substr(0, GetTextLength());
-
-    /* If clipboard data in UNICODE and was created by old Borland products they all
-       have same bug: create unicode-like data in clipboard but actually its
-       simple text in ACP codepage "expanded" to unicode by zeroes like this:
-         "text"
-       will be:
-         "t\x00e\x00x\x00t\x00\x00\x00"
-       This works as UNICODE for ansi chars but failed with any international
-       multibyte codepages like win1251.
-
-       Solution:
-         - compress original text back to MB
-         - convert it to correct unicode replacing data read from clipboard
-
-       !!NOTE: This code assumes what ANY application which put data to clipboard
-               using borland-clipboard-flag has this bug.
-               All versions of old Borland products I know (Builder, Delphi) has it
-               but may be some exceptions exists,
-    */
-    if (IsOldBorlandText()) {
-
-      //Make temp buffer for multibyte string
-      auto buff = std::make_unique<char[]>( Data.length() );
-
-      //Compress fake unicode back to multibyte
-      auto src = Data.c_str();
-      auto b = buff.get();
-      int sz = 0;
-      for (; *src && sz < (int)Data.length(); src++, sz++)
-        *b++ = *src & 0xFF;
-
-      /* Little optimization bonus.
-         In originl FAR try to insert zero-length text from clipboard.
-         Iv no idea why
-      */
-      if ( !sz ) return false;
-
-      //Create correct unicode inplace (terminating zero included)
-      sz++;
-      MultiByteToWideChar(CP_ACP, 0, buff.get(), sz, (LPWSTR)Data.c_str(), sz );
-    }
-
-    return true;
-  }
-
-  bool GetVText(string& Data) const override
-  {
-    const auto IsBorlandVerticalBlock = []
-    {
-      const auto BlockFormat = RegisterFormat(clipboard_format::borland_ide_dev_block);
-      if (!BlockFormat)
-        return false;
-
-      if (!IsFormatAvailable(BlockFormat))
-        return false;
-
-      const auto BlockHandle = GetClipboardData(BlockFormat);
-      if (!BlockHandle)
-      {
-        LOGWARNING(L"GetClipboardData(): {}"sv, last_error());
-        return false;
-      }
-
-      const auto BlockPtr = os::memory::global::lock<const char*>(BlockHandle);
-      if (!BlockPtr)
-      {
-        LOGWARNING(L"global::lock(): {}"sv, last_error());
-        return false;
-      }
-
-      return *BlockPtr == '\2';
-    };
-
-    if (IsFormatAvailable(RegisterFormat(clipboard_format::vertical_block_unicode)) ||
-      IsFormatAvailable(RegisterFormat(clipboard_format::ms_dev_column_select)) ||
-      IsBorlandVerticalBlock())
-    {
-      return GetText(Data);
-    }
-
-    const auto OemDataFormat = RegisterFormat(clipboard_format::vertical_block_oem);
-    if (!OemDataFormat)
-      return false;
-
-    if (!IsFormatAvailable(OemDataFormat))
-      return false;
-
-    const auto OemDataHandle = GetClipboardData(OemDataFormat);
-    if (!OemDataHandle)
-    {
-      LOGERROR(L"GetClipboardData(): {}"sv, last_error());
-      return false;
-    }
-
-    const auto OemDataPtr = os::memory::global::lock<const char*>(OemDataHandle);
-    if (!OemDataPtr)
-    {
-      LOGWARNING(L"global::lock(): {}"sv, last_error());
-      return false;
-    }
-
-    const std::string_view OemDataView(OemDataPtr.get(), GlobalSize(OemDataHandle) / sizeof(*OemDataPtr));
-    if (OemDataView.empty())
-    {
-      LOGWARNING(L"Insufficient data"sv);
-      return false;
-    }
-
-    const auto OemDataSize = static_cast<size_t>(std::find(ALL_CONST_RANGE(OemDataView), '\0') - OemDataView.cbegin());
-    encoding::oem::get_chars(OemDataView.substr(0, OemDataSize), Data);
-    return true;
-  }
+	~system_clipboard() override
+	{
+		system_clipboard::Close();
+	}
+
+	bool Open() override
+	{
+		assert(!m_Opened);
+
+		if (m_Opened)
+			return false;
+
+		// Clipboard is a shared resource
+		const size_t Attempts = 5;
+
+		for (const auto& i: irange(Attempts))
+		{
+			// TODO: this is bad, we should use a real window handle
+			if (OpenClipboard(console.GetWindow()))
+			{
+				m_Opened = true;
+				return true;
+			}
+
+			const auto Error = last_error();
+
+			if (Error.Win32Error == ERROR_ACCESS_DENIED)
+			{
+				if (const auto Window = GetOpenClipboardWindow())
+				{
+					DWORD Pid;
+					if (const auto ThreadId = GetWindowThreadProcessId(Window, &Pid))
+					{
+						LOGWARNING(L"Clipboard is locked by {} (PID {}, TID {})"sv, os::process::get_process_name(Pid), Pid, ThreadId);
+					}
+				}
+			}
+
+			LOGDEBUG(L"OpenClipboard(): {}"sv, Error);
+
+			os::chrono::sleep_for((i + 1) * 50ms);
+		}
+
+		LOGERROR(L"OpenClipboard(): {}"sv, last_error());
+		return false;
+	}
+
+	bool Close() noexcept override
+	{
+		// Closing already closed buffer is OK
+		if (!m_Opened)
+			return true;
+
+		if (!CloseClipboard())
+		{
+			LOGERROR(L"CloseClipboard(): {}"sv, last_error());
+			return false;
+		}
+
+		m_Opened = false;
+		return true;
+	}
+
+	bool Clear() override
+	{
+		assert(m_Opened);
+
+		if (!EmptyClipboard())
+		{
+			LOGERROR(L"EmptyClipboard(): {}"sv, last_error());
+			return false;
+		}
+
+		return true;
+	}
+
+	bool SetText(const string_view Str) override
+	{
+		if (!Clear())
+			return false;
+
+		auto hData = os::memory::global::copy(Str);
+		if (!hData)
+		{
+			LOGERROR(L"global::copy(): {}"sv, last_error());
+			return false;
+		}
+
+		if (!SetData(CF_UNICODETEXT, std::move(hData)))
+			return false;
+
+		// 'Notepad++ binary text length'
+		// return value is ignored - non-critical feature
+		if (const auto Format = RegisterFormat(clipboard_format::notepad_plusplus_binary_text_length))
+		{
+			if (auto Size = os::memory::global::copy(static_cast<uint32_t>(Str.size())))
+				SetData(Format, std::move(Size));
+			else
+				LOGWARNING(L"global::copy(): {}"sv, last_error());
+		}
+
+		// return value is ignored - non-critical feature
+		if (auto Locale = os::memory::global::copy(GetUserDefaultLCID()))
+			SetData(CF_LOCALE, std::move(Locale));
+		else
+			LOGWARNING(L"global::copy(): {}"sv, last_error());
+
+		return true;
+	}
+
+	bool SetVText(const string_view Str) override
+	{
+		if (!SetText(Str))
+			return false;
+
+		const auto FarVerticalBlock = RegisterFormat(clipboard_format::vertical_block_unicode);
+		if (!FarVerticalBlock)
+			return false;
+
+		if (!SetData(FarVerticalBlock, os::memory::global::copy(0)))
+			return false;
+
+		// 'Borland IDE Block Type'
+		// return value is ignored - non-critical feature
+		if (const auto Format = RegisterFormat(clipboard_format::borland_ide_dev_block))
+			SetData(Format, os::memory::global::copy('\2'));
+
+		// 'MSDEVColumnSelect'
+		// return value is ignored - non-critical feature
+		if (const auto Format = RegisterFormat(clipboard_format::ms_dev_column_select))
+			SetData(Format, os::memory::global::copy(0));
+
+		return true;
+	}
+
+	bool SetHDROP(const string_view NamesData, const bool Move) override
+	{
+		if (NamesData.empty())
+			return false;
+
+		auto Memory = os::memory::global::alloc(GMEM_MOVEABLE, sizeof(DROPFILES) + (NamesData.size() + 1) * sizeof(wchar_t));
+		if (!Memory)
+		{
+			LOGERROR(L"global::alloc(): {}"sv, last_error());
+			return false;
+		}
+
+		const auto Drop = os::memory::global::lock<LPDROPFILES>(Memory);
+		if (!Drop)
+		{
+			LOGERROR(L"global::lock(): {}"sv, last_error());
+			return false;
+		}
+
+		Drop->pFiles = static_cast<DWORD>(aligned_sizeof<DROPFILES, sizeof(wchar_t)>);
+		Drop->pt.x = 0;
+		Drop->pt.y = 0;
+		Drop->fNC = TRUE;
+		Drop->fWide = TRUE;
+		const auto NamesPtr = edit_as<wchar_t*>(Drop.get(), Drop->pFiles);
+		assert(is_aligned(*NamesPtr));
+		*copy_string(NamesData, NamesPtr) = {};
+
+		if (!Clear() || !SetData(CF_HDROP, std::move(Memory)))
+			return false;
+
+		auto DropEffect = os::memory::global::copy<DWORD>(Move? DROPEFFECT_MOVE : DROPEFFECT_COPY);
+		if (!DropEffect)
+		{
+			LOGERROR(L"global::copy(): {}"sv, last_error());
+			return false;
+		}
+
+		const auto Format = RegisterFormat(clipboard_format::preferred_drop_effect);
+		if (!Format)
+			return false;
+
+		return SetData(Format, std::move(DropEffect));
+	}
+
+	bool GetText(string& Data) const override
+	{
+		if (!IsFormatAvailable(CF_UNICODETEXT))
+			return GetHDROPAsText(Data);
+
+		//Check if clipboard has text in old borland format
+		const auto IsOldBorlandText = [] {
+			const auto BlockFormat = RegisterFormat(clipboard_format::borland_ide_dev_block);
+			if (!BlockFormat || !IsFormatAvailable(BlockFormat))
+       		return false;
+
+			const auto BlockHandle = GetClipboardData(BlockFormat);
+			return BlockHandle && GlobalSize(BlockHandle) > 0;
+		};
+
+		const auto DataHandle = GetClipboardData(CF_UNICODETEXT);
+		if (!DataHandle)
+		{
+			LOGERROR(L"GetClipboardData: {}"sv, last_error());
+			return false;
+		}
+
+		const auto DataPtr = os::memory::global::lock<const wchar_t*>(DataHandle);
+		if (!DataPtr)
+		{
+			LOGERROR(L"global::lock(): {}"sv, last_error());
+			return false;
+		}
+
+		const string_view DataView(DataPtr.get(), GlobalSize(DataHandle) / sizeof(*DataPtr));
+		if (DataView.empty())
+		{
+			LOGERROR(L"Insufficient data"sv);
+			return false;
+		}
+
+		const auto GetBinaryTextLength = []() -> std::optional<size_t>
+		{
+			const auto SizeFormat = RegisterFormat(clipboard_format::notepad_plusplus_binary_text_length);
+			if (!SizeFormat)
+				return {};
+
+			if (!IsFormatAvailable(SizeFormat))
+				return {};
+
+			const auto SizeHandle = GetClipboardData(SizeFormat);
+			if (!SizeHandle)
+			{
+				LOGWARNING(L"GetClipboardData(): {}"sv, last_error());
+				return {};
+			}
+
+			const auto SizePtr = os::memory::global::lock<const uint32_t*>(SizeHandle);
+			if (!SizePtr)
+			{
+				LOGWARNING(L"global::lock(): {}"sv, last_error());
+				return {};
+			}
+
+			const auto Size = view_as_opt<uint32_t>(SizePtr.get(), GlobalSize(SizeHandle));
+			if (!Size)
+			{
+				LOGWARNING(L"Insufficient data"sv);
+				return {};
+			}
+
+			return *Size;
+		};
+
+		const auto GetTextLength = [&]
+		{
+			if (const auto Length = GetBinaryTextLength())
+				return *Length;
+
+			return static_cast<size_t>(std::find(ALL_CONST_RANGE(DataView), L'\0') - DataView.cbegin());
+		};
+
+		Data = DataView.substr(0, GetTextLength());
+
+		/* If clipboard data in UNICODE and was created by old Borland products they all
+			 have same bug: create unicode-like data in clipboard but actually its
+			 simple text in ACP codepage "expanded" to unicode by zeroes like this:
+				"text"
+			 will be:
+				"t\x00e\x00x\x00t\x00\x00\x00"
+			 This works as UNICODE for ansi chars but failed with any international
+			 multibyte codepages like win1251.
+
+			 Solution:
+				- compress original text back to MB
+				- convert it to correct unicode replacing data read from clipboard
+
+			 !!NOTE: This code assumes what ANY application which put data to clipboard
+						using borland-clipboard-flag has this bug.
+						All versions of old Borland products I know (Builder, Delphi) has it
+						but may be some exceptions exists,
+		*/
+		if (IsOldBorlandText()) {
+			//Make temp buffer for multibyte string
+			auto buff = std::make_unique<char[]>( Data.length() );
+
+			//Compress fake unicode back to multibyte
+			auto src = Data.c_str();
+			auto b = buff.get();
+			int sz = 0;
+			for (; *src && sz < (int)Data.length(); src++, sz++)
+			  *b++ = *src & 0xFF;
+
+			/* Little optimization bonus.
+				In originl FAR try to insert zero-length text from clipboard.
+				Iv no idea why
+			*/
+			if ( !sz ) return false;
+
+			//Create correct unicode inplace (terminating zero included)
+			sz++;
+			MultiByteToWideChar(CP_ACP, 0, buff.get(), sz, (LPWSTR)Data.c_str(), sz );
+		}
+
+		return true;
+	}
+
+	bool GetVText(string& Data) const override
+	{
+		const auto IsBorlandVerticalBlock = []
+		{
+			const auto BlockFormat = RegisterFormat(clipboard_format::borland_ide_dev_block);
+			if (!BlockFormat)
+				return false;
+
+			if (!IsFormatAvailable(BlockFormat))
+				return false;
+
+			const auto BlockHandle = GetClipboardData(BlockFormat);
+			if (!BlockHandle)
+			{
+				LOGWARNING(L"GetClipboardData(): {}"sv, last_error());
+				return false;
+			}
+
+			const auto BlockPtr = os::memory::global::lock<const char*>(BlockHandle);
+			if (!BlockPtr)
+			{
+				LOGWARNING(L"global::lock(): {}"sv, last_error());
+				return false;
+			}
+
+			return *BlockPtr == '\2';
+		};
+
+		if (IsFormatAvailable(RegisterFormat(clipboard_format::vertical_block_unicode)) ||
+			IsFormatAvailable(RegisterFormat(clipboard_format::ms_dev_column_select)) ||
+			IsBorlandVerticalBlock())
+		{
+			return GetText(Data);
+		}
+
+		const auto OemDataFormat = RegisterFormat(clipboard_format::vertical_block_oem);
+		if (!OemDataFormat)
+			return false;
+
+		if (!IsFormatAvailable(OemDataFormat))
+			return false;
+
+		const auto OemDataHandle = GetClipboardData(OemDataFormat);
+		if (!OemDataHandle)
+		{
+			LOGERROR(L"GetClipboardData(): {}"sv, last_error());
+			return false;
+		}
+
+		const auto OemDataPtr = os::memory::global::lock<const char*>(OemDataHandle);
+		if (!OemDataPtr)
+		{
+			LOGWARNING(L"global::lock(): {}"sv, last_error());
+			return false;
+		}
+
+		const std::string_view OemDataView(OemDataPtr.get(), GlobalSize(OemDataHandle) / sizeof(*OemDataPtr));
+		if (OemDataView.empty())
+		{
+			LOGWARNING(L"Insufficient data"sv);
+			return false;
+		}
+
+		const auto OemDataSize = static_cast<size_t>(std::find(ALL_CONST_RANGE(OemDataView), '\0') - OemDataView.cbegin());
+		encoding::oem::get_chars(OemDataView.substr(0, OemDataSize), Data);
+		return true;
+	}
 
 private:
-  system_clipboard() = default;
+	system_clipboard() = default;
 
-  template<typename char_type>
-  static bool copy_strings(string& To, const DROPFILES* Drop, size_t Size)
-  {
-    const auto Names = std::basic_string_view(view_as<const char_type*>(Drop, Drop->pFiles), (Size - Drop->pFiles) / sizeof(char_type));
-    if (Names.empty())
-      return false;
+	template<typename char_type>
+	static bool copy_strings(string& To, const DROPFILES* Drop, size_t Size)
+	{
+		const auto Names = std::basic_string_view(view_as<const char_type*>(Drop, Drop->pFiles), (Size - Drop->pFiles) / sizeof(char_type));
+		if (Names.empty())
+			return false;
 
-    const auto Eol = eol::system.str();
-    string Buffer;
+		const auto Eol = eol::system.str();
+		string Buffer;
 
-    for (const auto& i: enum_substrings(Names))
-    {
-      if constexpr (std::is_same_v<char_type, wchar_t>)
-      {
-        append(To, i, Eol);
-      }
-      else
-      {
-        Buffer.clear();
-        encoding::ansi::get_chars(i, Buffer);
-        append(To, Buffer, Eol);
-      }
-    }
+		for (const auto& i: enum_substrings(Names))
+		{
+			if constexpr (std::is_same_v<char_type, wchar_t>)
+			{
+				append(To, i, Eol);
+			}
+			else
+			{
+				Buffer.clear();
+				encoding::ansi::get_chars(i, Buffer);
+				append(To, Buffer, Eol);
+			}
+		}
 
-    return true;
-  }
+		return true;
+	}
 
-  bool GetHDROPAsText(string& data) const
-  {
-    if (!IsFormatAvailable(CF_HDROP))
-      return false;
+	bool GetHDROPAsText(string& data) const
+	{
+		if (!IsFormatAvailable(CF_HDROP))
+			return false;
 
-    const auto DropHandle = GetClipboardData(CF_HDROP);
-    if (!DropHandle)
-    {
-      LOGWARNING(L"GetClipboardData(): {}"sv, last_error());
-      return false;
-    }
+		const auto DropHandle = GetClipboardData(CF_HDROP);
+		if (!DropHandle)
+		{
+			LOGWARNING(L"GetClipboardData(): {}"sv, last_error());
+			return false;
+		}
 
-    const auto DropPtr = os::memory::global::lock<const DROPFILES*>(DropHandle);
-    if (!DropPtr)
-    {
-      LOGWARNING(L"global::lock(): {}"sv, last_error());
-      return false;
-    }
+		const auto DropPtr = os::memory::global::lock<const DROPFILES*>(DropHandle);
+		if (!DropPtr)
+		{
+			LOGWARNING(L"global::lock(): {}"sv, last_error());
+			return false;
+		}
 
-    const auto HandleSize = GlobalSize(DropHandle);
+		const auto HandleSize = GlobalSize(DropHandle);
 
-    const auto Drop = view_as_opt<DROPFILES>(DropPtr.get(), HandleSize);
-    if (!Drop)
-    {
-      LOGWARNING(L"Insufficient data"sv);
-      return false;
-    }
+		const auto Drop = view_as_opt<DROPFILES>(DropPtr.get(), HandleSize);
+		if (!Drop)
+		{
+			LOGWARNING(L"Insufficient data"sv);
+			return false;
+		}
 
-    const auto Copy = Drop->fWide? copy_strings<wchar_t> : copy_strings<char>;
+		const auto Copy = Drop->fWide? copy_strings<wchar_t> : copy_strings<char>;
 
-    return Copy(data, Drop, HandleSize);
-  }
+		return Copy(data, Drop, HandleSize);
+	}
 
-  bool SetData(unsigned const Format, os::memory::global::ptr&& Data) const
-  {
-    assert(m_Opened);
+	bool SetData(unsigned const Format, os::memory::global::ptr&& Data) const
+	{
+		assert(m_Opened);
 
-    if (!SetClipboardData(Format, Data.get()))
-    {
-      LOGWARNING(L"SetClipboardData(): {}"sv, last_error());
-      return false;
-    }
+		if (!SetClipboardData(Format, Data.get()))
+		{
+			LOGWARNING(L"SetClipboardData(): {}"sv, last_error());
+			return false;
+		}
 
-    // Owned by the OS now
-    (void)Data.release();
+		// Owned by the OS now
+		(void)Data.release();
 
-    return true;
-  }
+		return true;
+	}
 
-  static unsigned RegisterFormat(clipboard_format Format)
-  {
-    static std::pair<const wchar_t*, unsigned> FormatNames[]
-    {
-      { L"FAR_VerticalBlock", 0 },
-      { L"FAR_VerticalBlock_Unicode", 0 },
-      { CFSTR_PREFERREDDROPEFFECT, 0 },
-      { L"MSDEVColumnSelect", 0 },
-      { L"Borland IDE Block Type", 0 },
-      { L"Notepad++ binary text length", 0 },
-    };
+	static unsigned RegisterFormat(clipboard_format Format)
+	{
+		static std::pair<const wchar_t*, unsigned> FormatNames[]
+		{
+			{ L"FAR_VerticalBlock", 0 },
+			{ L"FAR_VerticalBlock_Unicode", 0 },
+			{ CFSTR_PREFERREDDROPEFFECT, 0 },
+			{ L"MSDEVColumnSelect", 0 },
+			{ L"Borland IDE Block Type", 0 },
+			{ L"Notepad++ binary text length", 0 },
+		};
 
-    static_assert(std::size(FormatNames) == static_cast<size_t>(clipboard_format::count));
-    assert(Format < clipboard_format::count);
-    auto& [FormatName, FormatId] = FormatNames[static_cast<unsigned>(Format)];
-    if (!FormatId)
-    {
-      FormatId = RegisterClipboardFormat(FormatName);
-      if (!FormatId)
-      {
-        LOGWARNING(L"RegisterClipboardFormat(): {}"sv, last_error());
-      }
-    }
-    return FormatId;
-  }
+		static_assert(std::size(FormatNames) == static_cast<size_t>(clipboard_format::count));
+		assert(Format < clipboard_format::count);
+		auto& [FormatName, FormatId] = FormatNames[static_cast<unsigned>(Format)];
+		if (!FormatId)
+		{
+			FormatId = RegisterClipboardFormat(FormatName);
+			if (!FormatId)
+			{
+				LOGWARNING(L"RegisterClipboardFormat(): {}"sv, last_error());
+			}
+		}
+		return FormatId;
+	}
 
-  static bool IsFormatAvailable(unsigned Format)
-  {
-    return Format && IsClipboardFormatAvailable(Format);
-  }
+	static bool IsFormatAvailable(unsigned Format)
+	{
+		return Format && IsClipboardFormatAvailable(Format);
+	}
 };
 
 //-----------------------------------------------------------------------------
 class internal_clipboard final: public clipboard, public singleton<internal_clipboard>
 {
-  IMPLEMENTS_SINGLETON;
+	IMPLEMENTS_SINGLETON;
 
 public:
-  static auto CreateInstance()
-  {
-    return std::unique_ptr<clipboard>(new internal_clipboard);
-  }
+	static auto CreateInstance()
+	{
+		return std::unique_ptr<clipboard>(new internal_clipboard);
+	}
 
-  ~internal_clipboard() override
-  {
-    internal_clipboard::Close();
-  }
+	~internal_clipboard() override
+	{
+		internal_clipboard::Close();
+	}
 
-  bool Open() override
-  {
-    assert(!m_Opened);
+	bool Open() override
+	{
+		assert(!m_Opened);
 
-    if (m_Opened)
-      return false;
+		if (m_Opened)
+			return false;
 
-    m_Opened = true;
-    return true;
-  }
+		m_Opened = true;
+		return true;
+	}
 
-  bool Close() noexcept override
-  {
-    // Closing already closed buffer is OK
-    m_Opened = false;
-    return true;
-  }
+	bool Close() noexcept override
+	{
+		// Closing already closed buffer is OK
+		m_Opened = false;
+		return true;
+	}
 
-  bool Clear() override
-  {
-    assert(m_Opened);
+	bool Clear() override
+	{
+		assert(m_Opened);
 
-    if (!m_Opened)
-      return false;
+		if (!m_Opened)
+			return false;
 
-    m_Data.reset();
-    return true;
-  }
+		m_Data.reset();
+		return true;
+	}
 
-  bool SetText(string_view Str) override
-  {
-    assert(m_Opened);
+	bool SetText(string_view Str) override
+	{
+		assert(m_Opened);
 
-    if (!m_Opened)
-      return false;
+		if (!m_Opened)
+			return false;
 
-    m_Data = Str;
-    m_Vertical = false;
+		m_Data = Str;
+		m_Vertical = false;
 
-    return true;
-  }
+		return true;
+	}
 
-  bool SetVText(string_view Str) override
-  {
-    assert(m_Opened);
+	bool SetVText(string_view Str) override
+	{
+		assert(m_Opened);
 
-    if (!m_Opened)
-      return false;
+		if (!m_Opened)
+			return false;
 
-    m_Data = Str;
-    m_Vertical = true;
+		m_Data = Str;
+		m_Vertical = true;
 
-    return true;
-  }
+		return true;
+	}
 
-  bool SetHDROP(string_view NamesData, bool Moved) override
-  {
-    return false;
-  }
+	bool SetHDROP(string_view NamesData, bool Moved) override
+	{
+		return false;
+	}
 
-  bool GetText(string& Data) const override
-  {
-    assert(m_Opened);
+	bool GetText(string& Data) const override
+	{
+		assert(m_Opened);
 
-    if (!m_Opened)
-      return false;
+		if (!m_Opened)
+			return false;
 
-    if (!m_Data)
-      return false;
+		if (!m_Data)
+			return false;
 
-    Data = *m_Data;
-    return true;
-  }
+		Data = *m_Data;
+		return true;
+	}
 
-  bool GetVText(string& Data) const override
-  {
-    assert(m_Opened);
+	bool GetVText(string& Data) const override
+	{
+		assert(m_Opened);
 
-    if (!m_Opened)
-      return false;
+		if (!m_Opened)
+			return false;
 
-    if (!m_Data)
-      return false;
+		if (!m_Data)
+			return false;
 
-    if (!m_Vertical)
-      return false;
+		if (!m_Vertical)
+			return false;
 
-    Data = *m_Data;
-    return true;
-  }
+		Data = *m_Data;
+		return true;
+	}
 
 private:
-  internal_clipboard() = default;
+	internal_clipboard() = default;
 
-  std::optional<string> m_Data;
-  bool m_Vertical;
+	std::optional<string> m_Data;
+	bool m_Vertical;
 };
 
 //-----------------------------------------------------------------------------
@@ -687,79 +686,79 @@ static thread_local clipboard* OverridenInternalClipboard;
 
 void clipboard_restorer::operator()(const clipboard* Clip) const noexcept
 {
-  OverridenInternalClipboard = nullptr;
-  delete Clip;
+	OverridenInternalClipboard = nullptr;
+	delete Clip;
 }
 
 std::unique_ptr<clipboard, clipboard_restorer> OverrideClipboard()
 {
-  auto ClipPtr = internal_clipboard::CreateInstance();
-  OverridenInternalClipboard = ClipPtr.get();
-  return std::unique_ptr<clipboard, clipboard_restorer>(ClipPtr.release());
+	auto ClipPtr = internal_clipboard::CreateInstance();
+	OverridenInternalClipboard = ClipPtr.get();
+	return std::unique_ptr<clipboard, clipboard_restorer>(ClipPtr.release());
 }
 
 clipboard& clipboard::GetInstance(clipboard_mode Mode)
 {
-  if (OverridenInternalClipboard)
-    return *OverridenInternalClipboard;
+	if (OverridenInternalClipboard)
+		return *OverridenInternalClipboard;
 
-  if (Mode == clipboard_mode::system)
-    return system_clipboard::instance();
+	if (Mode == clipboard_mode::system)
+		return system_clipboard::instance();
 
-  return internal_clipboard::instance();
+	return internal_clipboard::instance();
 }
 
 //-----------------------------------------------------------------------------
 bool SetClipboardText(const string_view Str)
 {
-  const clipboard_accessor Clip;
-  return Clip->Open() && Clip->SetText(Str);
+	const clipboard_accessor Clip;
+	return Clip->Open() && Clip->SetText(Str);
 }
 
 bool SetClipboardVText(const string_view Str)
 {
-  const clipboard_accessor Clip;
-  return Clip->Open() && Clip->SetVText(Str);
+	const clipboard_accessor Clip;
+	return Clip->Open() && Clip->SetVText(Str);
 }
 
 bool GetClipboardText(string& data)
 {
-  const clipboard_accessor Clip;
-  return Clip->Open() && Clip->GetText(data);
+	const clipboard_accessor Clip;
+	return Clip->Open() && Clip->GetText(data);
 }
 
 bool GetClipboardVText(string& data)
 {
-  const clipboard_accessor Clip;
-  return Clip->Open() && Clip->GetVText(data);
+	const clipboard_accessor Clip;
+	return Clip->Open() && Clip->GetVText(data);
 }
 
 bool ClearClipboard()
 {
-  const clipboard_accessor Clip;
-  return Clip->Open() && Clip->Clear();
+	const clipboard_accessor Clip;
+	return Clip->Open() && Clip->Clear();
 }
 
 bool ClearInternalClipboard()
 {
-  const clipboard_accessor Clip(clipboard_mode::internal);
-  return Clip->Open() && Clip->Clear();
+	const clipboard_accessor Clip(clipboard_mode::internal);
+	return Clip->Open() && Clip->Clear();
 }
 
 bool CopyData(const clipboard_accessor& From, const clipboard_accessor& To)
 {
-  string Data;
-  if (From->GetVText(Data))
-  {
-    return To->SetVText(Data);
-  }
+	string Data;
+	if (From->GetVText(Data))
+	{
+		return To->SetVText(Data);
+	}
 
-  if (From->GetText(Data))
-  {
-    return To->SetText(Data);
-  }
+	if (From->GetText(Data))
+	{
+		return To->SetText(Data);
+	}
 
-  return false;
+	return false;
 }
 
 #ifdef ENABLE_TESTS
@@ -769,97 +768,97 @@ bool CopyData(const clipboard_accessor& From, const clipboard_accessor& To)
 class clipboard_guard
 {
 public:
-  NONCOPYABLE(clipboard_guard);
+	NONCOPYABLE(clipboard_guard);
 
-  clipboard_guard()
-  {
-    const clipboard_accessor Clip(clipboard_mode::system);
-    if (!Clip->Open())
-      return;
+	clipboard_guard()
+	{
+		const clipboard_accessor Clip(clipboard_mode::system);
+		if (!Clip->Open())
+			return;
 
-    m_Data.reserve(CountClipboardFormats());
+		m_Data.reserve(CountClipboardFormats());
 
-    for (auto i = EnumClipboardFormats(0); i; i = EnumClipboardFormats(i))
-    {
-      if (i == CF_BITMAP || i == CF_ENHMETAFILE)
-        continue;
+		for (auto i = EnumClipboardFormats(0); i; i = EnumClipboardFormats(i))
+		{
+			if (i == CF_BITMAP || i == CF_ENHMETAFILE)
+				continue;
 
-      m_Data.emplace_back(i, os::memory::global::copy(GetClipboardData(i)));
-    }
-  }
+			m_Data.emplace_back(i, os::memory::global::copy(GetClipboardData(i)));
+		}
+	}
 
-  ~clipboard_guard()
-  {
-    if (m_Data.empty())
-      return;
+	~clipboard_guard()
+	{
+		if (m_Data.empty())
+			return;
 
-    const clipboard_accessor Clip(clipboard_mode::system);
-    if (!Clip->Open())
-      return;
+		const clipboard_accessor Clip(clipboard_mode::system);
+		if (!Clip->Open())
+			return;
 
-    for (auto& [Format, Data]: m_Data)
-    {
-      SetClipboardData(Format, Data.release());
-    }
-  }
+		for (auto& [Format, Data]: m_Data)
+		{
+			SetClipboardData(Format, Data.release());
+		}
+	}
 
 private:
-  std::vector<std::pair<unsigned, os::memory::global::ptr>> m_Data;
+	std::vector<std::pair<unsigned, os::memory::global::ptr>> m_Data;
 };
 
 TEST_CASE("clipboard.stream")
 {
-  SCOPED_ACTION(clipboard_guard);
+	SCOPED_ACTION(clipboard_guard);
 
-  const auto Baseline = L"\0 Comfortably Numb \0"sv;
-  string Str;
+	const auto Baseline = L"\0 Comfortably Numb \0"sv;
+	string Str;
 
-  const auto Mode = default_clipboard_mode::get();
+	const auto Mode = default_clipboard_mode::get();
 
-  const std::array Types
-  {
-    std::pair{&SetClipboardText, &GetClipboardText},
-    std::pair{&SetClipboardVText, &GetClipboardVText},
-  };
+	const std::array Types
+	{
+		std::pair{&SetClipboardText, &GetClipboardText},
+		std::pair{&SetClipboardVText, &GetClipboardVText},
+	};
 
-  for (const auto i: { clipboard_mode::system, clipboard_mode::internal })
-  {
-    default_clipboard_mode::set(i);
+	for (const auto i: { clipboard_mode::system, clipboard_mode::internal })
+	{
+		default_clipboard_mode::set(i);
 
-    for (const auto& [Set, Get]: Types)
-    {
-      REQUIRE(Set(Baseline));
-      REQUIRE(Get(Str));
-      REQUIRE(Str == Baseline);
+		for (const auto& [Set, Get]: Types)
+		{
+			REQUIRE(Set(Baseline));
+			REQUIRE(Get(Str));
+			REQUIRE(Str == Baseline);
 
-      REQUIRE(ClearClipboard());
-      REQUIRE(!Get(Str));
-    }
-  }
+			REQUIRE(ClearClipboard());
+			REQUIRE(!Get(Str));
+		}
+	}
 
-  default_clipboard_mode::set(Mode);
+	default_clipboard_mode::set(Mode);
 }
 
 TEST_CASE("clipboard.accessors")
 {
-  SCOPED_ACTION(clipboard_guard);
+	SCOPED_ACTION(clipboard_guard);
 
-  const auto Baseline = L"\0 Hey Macarena \0"sv;
-  string Str;
+	const auto Baseline = L"\0 Hey Macarena \0"sv;
+	string Str;
 
-  const clipboard_accessor
-    ClipSystem(clipboard_mode::system),
-    ClipInternal(clipboard_mode::internal);
+	const clipboard_accessor
+		ClipSystem(clipboard_mode::system),
+		ClipInternal(clipboard_mode::internal);
 
-  REQUIRE(ClipSystem->Open());
-  REQUIRE(ClipSystem->SetText(Baseline));
-  REQUIRE(ClipInternal->Open());
-  REQUIRE(CopyData(ClipSystem, ClipInternal));
-  REQUIRE(ClipSystem->Clear());
-  REQUIRE(ClipSystem->Close());
-  REQUIRE(ClipInternal->GetText(Str));
-  REQUIRE(ClipInternal->Clear());
-  REQUIRE(ClipInternal->Close());
-  REQUIRE(Str == Baseline);
+	REQUIRE(ClipSystem->Open());
+	REQUIRE(ClipSystem->SetText(Baseline));
+	REQUIRE(ClipInternal->Open());
+	REQUIRE(CopyData(ClipSystem, ClipInternal));
+	REQUIRE(ClipSystem->Clear());
+	REQUIRE(ClipSystem->Close());
+	REQUIRE(ClipInternal->GetText(Str));
+	REQUIRE(ClipInternal->Clear());
+	REQUIRE(ClipInternal->Close());
+	REQUIRE(Str == Baseline);
 }
 #endif

--- a/far/clipboard.cpp
+++ b/far/clipboard.cpp
@@ -365,15 +365,16 @@ public:
 		*/
 		if (IsOldBorlandText())
 		{
-		  const auto CheckAnsiOnly = [&](auto src, int maxS) -> int
+		  const auto CheckAnsiOnly = [&]() -> int
 		  {
+			auto src = Data.c_str();
 			int sz = 0;
-			for (sz = 0; sz < maxS && *src; src++, sz++)
+			for (sz = 0; sz < (int)Data.length() && *src; src++, sz++)
 			  if ((*src & 0xFF00) != 0)
 				return 0;
 			return sz;
 		  };
-		  int sz = CheckAnsiOnly(Data.c_str(), Data.length());
+		  int sz = CheckAnsiOnly();
 		  if (sz)
 		  {
 			auto buff = std::make_unique<char[]>(Data.length());

--- a/far/clipboard.cpp
+++ b/far/clipboard.cpp
@@ -59,575 +59,627 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 void default_clipboard_mode::set(clipboard_mode Mode) noexcept
 {
-	m_Mode = Mode;
+  m_Mode = Mode;
 }
 
 clipboard_mode default_clipboard_mode::get() noexcept
 {
-	return m_Mode;
+  return m_Mode;
 }
 
 //-----------------------------------------------------------------------------
 enum class clipboard_format
 {
-	vertical_block_oem,
-	vertical_block_unicode,
-	preferred_drop_effect,
-	ms_dev_column_select,
-	borland_ide_dev_block,
-	notepad_plusplus_binary_text_length,
+  vertical_block_oem,
+  vertical_block_unicode,
+  preferred_drop_effect,
+  ms_dev_column_select,
+  borland_ide_dev_block,
+  notepad_plusplus_binary_text_length,
 
-	count
+  count
 };
 
 //-----------------------------------------------------------------------------
 class system_clipboard final: public clipboard, public singleton<system_clipboard>
 {
-	IMPLEMENTS_SINGLETON;
+  IMPLEMENTS_SINGLETON;
 
 public:
-	~system_clipboard() override
-	{
-		system_clipboard::Close();
-	}
+  ~system_clipboard() override
+  {
+    system_clipboard::Close();
+  }
 
-	bool Open() override
-	{
-		assert(!m_Opened);
+  bool Open() override
+  {
+    assert(!m_Opened);
 
-		if (m_Opened)
-			return false;
+    if (m_Opened)
+      return false;
 
-		// Clipboard is a shared resource
-		const size_t Attempts = 5;
+    // Clipboard is a shared resource
+    const size_t Attempts = 5;
 
-		for (const auto& i: irange(Attempts))
-		{
-			// TODO: this is bad, we should use a real window handle
-			if (OpenClipboard(console.GetWindow()))
-			{
-				m_Opened = true;
-				return true;
-			}
+    for (const auto& i: irange(Attempts))
+    {
+      // TODO: this is bad, we should use a real window handle
+      if (OpenClipboard(console.GetWindow()))
+      {
+        m_Opened = true;
+        return true;
+      }
 
-			const auto Error = last_error();
+      const auto Error = last_error();
 
-			if (Error.Win32Error == ERROR_ACCESS_DENIED)
-			{
-				if (const auto Window = GetOpenClipboardWindow())
-				{
-					DWORD Pid;
-					if (const auto ThreadId = GetWindowThreadProcessId(Window, &Pid))
-					{
-						LOGWARNING(L"Clipboard is locked by {} (PID {}, TID {})"sv, os::process::get_process_name(Pid), Pid, ThreadId);
-					}
-				}
-			}
+      if (Error.Win32Error == ERROR_ACCESS_DENIED)
+      {
+        if (const auto Window = GetOpenClipboardWindow())
+        {
+          DWORD Pid;
+          if (const auto ThreadId = GetWindowThreadProcessId(Window, &Pid))
+          {
+            LOGWARNING(L"Clipboard is locked by {} (PID {}, TID {})"sv, os::process::get_process_name(Pid), Pid, ThreadId);
+          }
+        }
+      }
 
-			LOGDEBUG(L"OpenClipboard(): {}"sv, Error);
+      LOGDEBUG(L"OpenClipboard(): {}"sv, Error);
 
-			os::chrono::sleep_for((i + 1) * 50ms);
-		}
+      os::chrono::sleep_for((i + 1) * 50ms);
+    }
 
-		LOGERROR(L"OpenClipboard(): {}"sv, last_error());
-		return false;
-	}
+    LOGERROR(L"OpenClipboard(): {}"sv, last_error());
+    return false;
+  }
 
-	bool Close() noexcept override
-	{
-		// Closing already closed buffer is OK
-		if (!m_Opened)
-			return true;
+  bool Close() noexcept override
+  {
+    // Closing already closed buffer is OK
+    if (!m_Opened)
+      return true;
 
-		if (!CloseClipboard())
-		{
-			LOGERROR(L"CloseClipboard(): {}"sv, last_error());
-			return false;
-		}
+    if (!CloseClipboard())
+    {
+      LOGERROR(L"CloseClipboard(): {}"sv, last_error());
+      return false;
+    }
 
-		m_Opened = false;
-		return true;
-	}
+    m_Opened = false;
+    return true;
+  }
 
-	bool Clear() override
-	{
-		assert(m_Opened);
+  bool Clear() override
+  {
+    assert(m_Opened);
 
-		if (!EmptyClipboard())
-		{
-			LOGERROR(L"EmptyClipboard(): {}"sv, last_error());
-			return false;
-		}
+    if (!EmptyClipboard())
+    {
+      LOGERROR(L"EmptyClipboard(): {}"sv, last_error());
+      return false;
+    }
 
-		return true;
-	}
+    return true;
+  }
 
-	bool SetText(const string_view Str) override
-	{
-		if (!Clear())
-			return false;
+  bool SetText(const string_view Str) override
+  {
+    if (!Clear())
+      return false;
 
-		auto hData = os::memory::global::copy(Str);
-		if (!hData)
-		{
-			LOGERROR(L"global::copy(): {}"sv, last_error());
-			return false;
-		}
+    auto hData = os::memory::global::copy(Str);
+    if (!hData)
+    {
+      LOGERROR(L"global::copy(): {}"sv, last_error());
+      return false;
+    }
 
-		if (!SetData(CF_UNICODETEXT, std::move(hData)))
-			return false;
+    if (!SetData(CF_UNICODETEXT, std::move(hData)))
+      return false;
 
-		// 'Notepad++ binary text length'
-		// return value is ignored - non-critical feature
-		if (const auto Format = RegisterFormat(clipboard_format::notepad_plusplus_binary_text_length))
-		{
-			if (auto Size = os::memory::global::copy(static_cast<uint32_t>(Str.size())))
-				SetData(Format, std::move(Size));
-			else
-				LOGWARNING(L"global::copy(): {}"sv, last_error());
-		}
+    // 'Notepad++ binary text length'
+    // return value is ignored - non-critical feature
+    if (const auto Format = RegisterFormat(clipboard_format::notepad_plusplus_binary_text_length))
+    {
+      if (auto Size = os::memory::global::copy(static_cast<uint32_t>(Str.size())))
+        SetData(Format, std::move(Size));
+      else
+        LOGWARNING(L"global::copy(): {}"sv, last_error());
+    }
 
-		// return value is ignored - non-critical feature
-		if (auto Locale = os::memory::global::copy(GetUserDefaultLCID()))
-			SetData(CF_LOCALE, std::move(Locale));
-		else
-			LOGWARNING(L"global::copy(): {}"sv, last_error());
+    // return value is ignored - non-critical feature
+    if (auto Locale = os::memory::global::copy(GetUserDefaultLCID()))
+      SetData(CF_LOCALE, std::move(Locale));
+    else
+      LOGWARNING(L"global::copy(): {}"sv, last_error());
 
-		return true;
-	}
+    return true;
+  }
 
-	bool SetVText(const string_view Str) override
-	{
-		if (!SetText(Str))
-			return false;
+  bool SetVText(const string_view Str) override
+  {
+    if (!SetText(Str))
+      return false;
 
-		const auto FarVerticalBlock = RegisterFormat(clipboard_format::vertical_block_unicode);
-		if (!FarVerticalBlock)
-			return false;
+    const auto FarVerticalBlock = RegisterFormat(clipboard_format::vertical_block_unicode);
+    if (!FarVerticalBlock)
+      return false;
 
-		if (!SetData(FarVerticalBlock, os::memory::global::copy(0)))
-			return false;
+    if (!SetData(FarVerticalBlock, os::memory::global::copy(0)))
+      return false;
 
-		// 'Borland IDE Block Type'
-		// return value is ignored - non-critical feature
-		if (const auto Format = RegisterFormat(clipboard_format::borland_ide_dev_block))
-			SetData(Format, os::memory::global::copy('\2'));
+    // 'Borland IDE Block Type'
+    // return value is ignored - non-critical feature
+    if (const auto Format = RegisterFormat(clipboard_format::borland_ide_dev_block))
+      SetData(Format, os::memory::global::copy('\2'));
 
-		// 'MSDEVColumnSelect'
-		// return value is ignored - non-critical feature
-		if (const auto Format = RegisterFormat(clipboard_format::ms_dev_column_select))
-			SetData(Format, os::memory::global::copy(0));
+    // 'MSDEVColumnSelect'
+    // return value is ignored - non-critical feature
+    if (const auto Format = RegisterFormat(clipboard_format::ms_dev_column_select))
+      SetData(Format, os::memory::global::copy(0));
 
-		return true;
-	}
+    return true;
+  }
 
-	bool SetHDROP(const string_view NamesData, const bool Move) override
-	{
-		if (NamesData.empty())
-			return false;
+  bool SetHDROP(const string_view NamesData, const bool Move) override
+  {
+    if (NamesData.empty())
+      return false;
 
-		auto Memory = os::memory::global::alloc(GMEM_MOVEABLE, sizeof(DROPFILES) + (NamesData.size() + 1) * sizeof(wchar_t));
-		if (!Memory)
-		{
-			LOGERROR(L"global::alloc(): {}"sv, last_error());
-			return false;
-		}
+    auto Memory = os::memory::global::alloc(GMEM_MOVEABLE, sizeof(DROPFILES) + (NamesData.size() + 1) * sizeof(wchar_t));
+    if (!Memory)
+    {
+      LOGERROR(L"global::alloc(): {}"sv, last_error());
+      return false;
+    }
 
-		const auto Drop = os::memory::global::lock<LPDROPFILES>(Memory);
-		if (!Drop)
-		{
-			LOGERROR(L"global::lock(): {}"sv, last_error());
-			return false;
-		}
+    const auto Drop = os::memory::global::lock<LPDROPFILES>(Memory);
+    if (!Drop)
+    {
+      LOGERROR(L"global::lock(): {}"sv, last_error());
+      return false;
+    }
 
-		Drop->pFiles = static_cast<DWORD>(aligned_sizeof<DROPFILES, sizeof(wchar_t)>);
-		Drop->pt.x = 0;
-		Drop->pt.y = 0;
-		Drop->fNC = TRUE;
-		Drop->fWide = TRUE;
-		const auto NamesPtr = edit_as<wchar_t*>(Drop.get(), Drop->pFiles);
-		assert(is_aligned(*NamesPtr));
-		*copy_string(NamesData, NamesPtr) = {};
+    Drop->pFiles = static_cast<DWORD>(aligned_sizeof<DROPFILES, sizeof(wchar_t)>);
+    Drop->pt.x = 0;
+    Drop->pt.y = 0;
+    Drop->fNC = TRUE;
+    Drop->fWide = TRUE;
+    const auto NamesPtr = edit_as<wchar_t*>(Drop.get(), Drop->pFiles);
+    assert(is_aligned(*NamesPtr));
+    *copy_string(NamesData, NamesPtr) = {};
 
-		if (!Clear() || !SetData(CF_HDROP, std::move(Memory)))
-			return false;
+    if (!Clear() || !SetData(CF_HDROP, std::move(Memory)))
+      return false;
 
-		auto DropEffect = os::memory::global::copy<DWORD>(Move? DROPEFFECT_MOVE : DROPEFFECT_COPY);
-		if (!DropEffect)
-		{
-			LOGERROR(L"global::copy(): {}"sv, last_error());
-			return false;
-		}
+    auto DropEffect = os::memory::global::copy<DWORD>(Move? DROPEFFECT_MOVE : DROPEFFECT_COPY);
+    if (!DropEffect)
+    {
+      LOGERROR(L"global::copy(): {}"sv, last_error());
+      return false;
+    }
 
-		const auto Format = RegisterFormat(clipboard_format::preferred_drop_effect);
-		if (!Format)
-			return false;
+    const auto Format = RegisterFormat(clipboard_format::preferred_drop_effect);
+    if (!Format)
+      return false;
 
-		return SetData(Format, std::move(DropEffect));
-	}
+    return SetData(Format, std::move(DropEffect));
+  }
 
-	bool GetText(string& Data) const override
-	{
-		if (!IsFormatAvailable(CF_UNICODETEXT))
-			return GetHDROPAsText(Data);
+  bool GetText(string& Data) const override
+  {
+    //Check if clipboard has text in old borland format
+    const auto IsOldBorlandText = [] {
+     const auto BlockFormat = RegisterFormat(clipboard_format::borland_ide_dev_block);
+     if (!BlockFormat || !IsFormatAvailable(BlockFormat))
+       return false;
 
-		const auto DataHandle = GetClipboardData(CF_UNICODETEXT);
-		if (!DataHandle)
-		{
-			LOGERROR(L"GetClipboardData: {}"sv, last_error());
-			return false;
-		}
+     const auto BlockHandle = GetClipboardData(BlockFormat);
+     return BlockHandle && GlobalSize(BlockHandle) > 0;
+    };
 
-		const auto DataPtr = os::memory::global::lock<const wchar_t*>(DataHandle);
-		if (!DataPtr)
-		{
-			LOGERROR(L"global::lock(): {}"sv, last_error());
-			return false;
-		}
+    if (!IsFormatAvailable(CF_UNICODETEXT))
+      return GetHDROPAsText(Data);
 
-		const string_view DataView(DataPtr.get(), GlobalSize(DataHandle) / sizeof(*DataPtr));
-		if (DataView.empty())
-		{
-			LOGERROR(L"Insufficient data"sv);
-			return false;
-		}
+    const auto DataHandle = GetClipboardData(CF_UNICODETEXT);
+    if (!DataHandle)
+    {
+      LOGERROR(L"GetClipboardData: {}"sv, last_error());
+      return false;
+    }
 
-		const auto GetBinaryTextLength = []() -> std::optional<size_t>
-		{
-			const auto SizeFormat = RegisterFormat(clipboard_format::notepad_plusplus_binary_text_length);
-			if (!SizeFormat)
-				return {};
+    const auto DataPtr = os::memory::global::lock<const wchar_t*>(DataHandle);
+    if (!DataPtr)
+    {
+      LOGERROR(L"global::lock(): {}"sv, last_error());
+      return false;
+    }
 
-			if (!IsFormatAvailable(SizeFormat))
-				return {};
+    const string_view DataView(DataPtr.get(), GlobalSize(DataHandle) / sizeof(*DataPtr));
+    if (DataView.empty())
+    {
+      LOGERROR(L"Insufficient data"sv);
+      return false;
+    }
 
-			const auto SizeHandle = GetClipboardData(SizeFormat);
-			if (!SizeHandle)
-			{
-				LOGWARNING(L"GetClipboardData(): {}"sv, last_error());
-				return {};
-			}
+    const auto GetBinaryTextLength = []() -> std::optional<size_t>
+    {
+      const auto SizeFormat = RegisterFormat(clipboard_format::notepad_plusplus_binary_text_length);
+      if (!SizeFormat)
+        return {};
 
-			const auto SizePtr = os::memory::global::lock<const uint32_t*>(SizeHandle);
-			if (!SizePtr)
-			{
-				LOGWARNING(L"global::lock(): {}"sv, last_error());
-				return {};
-			}
+      if (!IsFormatAvailable(SizeFormat))
+        return {};
 
-			const auto Size = view_as_opt<uint32_t>(SizePtr.get(), GlobalSize(SizeHandle));
-			if (!Size)
-			{
-				LOGWARNING(L"Insufficient data"sv);
-				return {};
-			}
+      const auto SizeHandle = GetClipboardData(SizeFormat);
+      if (!SizeHandle)
+      {
+        LOGWARNING(L"GetClipboardData(): {}"sv, last_error());
+        return {};
+      }
 
-			return *Size;
-		};
+      const auto SizePtr = os::memory::global::lock<const uint32_t*>(SizeHandle);
+      if (!SizePtr)
+      {
+        LOGWARNING(L"global::lock(): {}"sv, last_error());
+        return {};
+      }
 
-		const auto GetTextLength = [&]
-		{
-			if (const auto Length = GetBinaryTextLength())
-				return *Length;
+      const auto Size = view_as_opt<uint32_t>(SizePtr.get(), GlobalSize(SizeHandle));
+      if (!Size)
+      {
+        LOGWARNING(L"Insufficient data"sv);
+        return {};
+      }
 
-			return static_cast<size_t>(std::find(ALL_CONST_RANGE(DataView), L'\0') - DataView.cbegin());
-		};
+      return *Size;
+    };
 
-		Data = DataView.substr(0, GetTextLength());
-		return true;
-	}
+    const auto GetTextLength = [&]
+    {
+      if (const auto Length = GetBinaryTextLength())
+        return *Length;
 
-	bool GetVText(string& Data) const override
-	{
-		const auto IsBorlandVerticalBlock = []
-		{
-			const auto BlockFormat = RegisterFormat(clipboard_format::borland_ide_dev_block);
-			if (!BlockFormat)
-				return false;
+      return static_cast<size_t>(std::find(ALL_CONST_RANGE(DataView), L'\0') - DataView.cbegin());
+    };
 
-			if (!IsFormatAvailable(BlockFormat))
-				return false;
+    Data = DataView.substr(0, GetTextLength());
 
-			const auto BlockHandle = GetClipboardData(BlockFormat);
-			if (!BlockHandle)
-			{
-				LOGWARNING(L"GetClipboardData(): {}"sv, last_error());
-				return false;
-			}
+    /* If clipboard data in UNICODE and was created by old Borland products they all
+       have same bug: create unicode-like data in clipboard but actually its
+       simple text in ACP codepage "expanded" to unicode by zeroes like this:
+         "text"
+       will be:
+         "t\x00e\x00x\x00t\x00\x00\x00"
+       This works as UNICODE for ansi chars but failed with any international
+       multibyte codepages like win1251.
 
-			const auto BlockPtr = os::memory::global::lock<const char*>(BlockHandle);
-			if (!BlockPtr)
-			{
-				LOGWARNING(L"global::lock(): {}"sv, last_error());
-				return false;
-			}
+       Solution:
+         - compress original text back to MB
+         - convert it to correct unicode replacing data read from clipboard
 
-			return *BlockPtr == '\2';
-		};
+       !!NOTE: This code assumes what ANY application which put data to clipboard
+               using borland-clipboard-flag has this bug.
+               All versions of old Borland products I know (Builder, Delphi) has it
+               but may be some exceptions exists,
+    */
+    if (IsOldBorlandText()) {
 
-		if (IsFormatAvailable(RegisterFormat(clipboard_format::vertical_block_unicode)) ||
-			IsFormatAvailable(RegisterFormat(clipboard_format::ms_dev_column_select)) ||
-			IsBorlandVerticalBlock())
-		{
-			return GetText(Data);
-		}
+      //Make temp buffer for multibyte string
+      auto buff = std::make_unique<char[]>( Data.length() );
 
-		const auto OemDataFormat = RegisterFormat(clipboard_format::vertical_block_oem);
-		if (!OemDataFormat)
-			return false;
+      //Compress fake unicode back to multibyte
+      auto src = Data.c_str();
+      auto b = buff.get();
+      int sz = 0;
+      for (; *src && sz < (int)Data.length(); src++, sz++)
+        *b++ = *src & 0xFF;
 
-		if (!IsFormatAvailable(OemDataFormat))
-			return false;
+      /* Little optimization bonus.
+         In originl FAR try to insert zero-length text from clipboard.
+         Iv no idea why
+      */
+      if ( !sz ) return false;
 
-		const auto OemDataHandle = GetClipboardData(OemDataFormat);
-		if (!OemDataHandle)
-		{
-			LOGERROR(L"GetClipboardData(): {}"sv, last_error());
-			return false;
-		}
+      //Create correct unicode inplace (terminating zero included)
+      sz++;
+      MultiByteToWideChar(CP_ACP, 0, buff.get(), sz, (LPWSTR)Data.c_str(), sz );
+    }
 
-		const auto OemDataPtr = os::memory::global::lock<const char*>(OemDataHandle);
-		if (!OemDataPtr)
-		{
-			LOGWARNING(L"global::lock(): {}"sv, last_error());
-			return false;
-		}
+    return true;
+  }
 
-		const std::string_view OemDataView(OemDataPtr.get(), GlobalSize(OemDataHandle) / sizeof(*OemDataPtr));
-		if (OemDataView.empty())
-		{
-			LOGWARNING(L"Insufficient data"sv);
-			return false;
-		}
+  bool GetVText(string& Data) const override
+  {
+    const auto IsBorlandVerticalBlock = []
+    {
+      const auto BlockFormat = RegisterFormat(clipboard_format::borland_ide_dev_block);
+      if (!BlockFormat)
+        return false;
 
-		const auto OemDataSize = static_cast<size_t>(std::find(ALL_CONST_RANGE(OemDataView), '\0') - OemDataView.cbegin());
-		encoding::oem::get_chars(OemDataView.substr(0, OemDataSize), Data);
-		return true;
-	}
+      if (!IsFormatAvailable(BlockFormat))
+        return false;
+
+      const auto BlockHandle = GetClipboardData(BlockFormat);
+      if (!BlockHandle)
+      {
+        LOGWARNING(L"GetClipboardData(): {}"sv, last_error());
+        return false;
+      }
+
+      const auto BlockPtr = os::memory::global::lock<const char*>(BlockHandle);
+      if (!BlockPtr)
+      {
+        LOGWARNING(L"global::lock(): {}"sv, last_error());
+        return false;
+      }
+
+      return *BlockPtr == '\2';
+    };
+
+    if (IsFormatAvailable(RegisterFormat(clipboard_format::vertical_block_unicode)) ||
+      IsFormatAvailable(RegisterFormat(clipboard_format::ms_dev_column_select)) ||
+      IsBorlandVerticalBlock())
+    {
+      return GetText(Data);
+    }
+
+    const auto OemDataFormat = RegisterFormat(clipboard_format::vertical_block_oem);
+    if (!OemDataFormat)
+      return false;
+
+    if (!IsFormatAvailable(OemDataFormat))
+      return false;
+
+    const auto OemDataHandle = GetClipboardData(OemDataFormat);
+    if (!OemDataHandle)
+    {
+      LOGERROR(L"GetClipboardData(): {}"sv, last_error());
+      return false;
+    }
+
+    const auto OemDataPtr = os::memory::global::lock<const char*>(OemDataHandle);
+    if (!OemDataPtr)
+    {
+      LOGWARNING(L"global::lock(): {}"sv, last_error());
+      return false;
+    }
+
+    const std::string_view OemDataView(OemDataPtr.get(), GlobalSize(OemDataHandle) / sizeof(*OemDataPtr));
+    if (OemDataView.empty())
+    {
+      LOGWARNING(L"Insufficient data"sv);
+      return false;
+    }
+
+    const auto OemDataSize = static_cast<size_t>(std::find(ALL_CONST_RANGE(OemDataView), '\0') - OemDataView.cbegin());
+    encoding::oem::get_chars(OemDataView.substr(0, OemDataSize), Data);
+    return true;
+  }
 
 private:
-	system_clipboard() = default;
+  system_clipboard() = default;
 
-	template<typename char_type>
-	static bool copy_strings(string& To, const DROPFILES* Drop, size_t Size)
-	{
-		const auto Names = std::basic_string_view(view_as<const char_type*>(Drop, Drop->pFiles), (Size - Drop->pFiles) / sizeof(char_type));
-		if (Names.empty())
-			return false;
+  template<typename char_type>
+  static bool copy_strings(string& To, const DROPFILES* Drop, size_t Size)
+  {
+    const auto Names = std::basic_string_view(view_as<const char_type*>(Drop, Drop->pFiles), (Size - Drop->pFiles) / sizeof(char_type));
+    if (Names.empty())
+      return false;
 
-		const auto Eol = eol::system.str();
-		string Buffer;
+    const auto Eol = eol::system.str();
+    string Buffer;
 
-		for (const auto& i: enum_substrings(Names))
-		{
-			if constexpr (std::is_same_v<char_type, wchar_t>)
-			{
-				append(To, i, Eol);
-			}
-			else
-			{
-				Buffer.clear();
-				encoding::ansi::get_chars(i, Buffer);
-				append(To, Buffer, Eol);
-			}
-		}
+    for (const auto& i: enum_substrings(Names))
+    {
+      if constexpr (std::is_same_v<char_type, wchar_t>)
+      {
+        append(To, i, Eol);
+      }
+      else
+      {
+        Buffer.clear();
+        encoding::ansi::get_chars(i, Buffer);
+        append(To, Buffer, Eol);
+      }
+    }
 
-		return true;
-	}
+    return true;
+  }
 
-	bool GetHDROPAsText(string& data) const
-	{
-		if (!IsFormatAvailable(CF_HDROP))
-			return false;
+  bool GetHDROPAsText(string& data) const
+  {
+    if (!IsFormatAvailable(CF_HDROP))
+      return false;
 
-		const auto DropHandle = GetClipboardData(CF_HDROP);
-		if (!DropHandle)
-		{
-			LOGWARNING(L"GetClipboardData(): {}"sv, last_error());
-			return false;
-		}
+    const auto DropHandle = GetClipboardData(CF_HDROP);
+    if (!DropHandle)
+    {
+      LOGWARNING(L"GetClipboardData(): {}"sv, last_error());
+      return false;
+    }
 
-		const auto DropPtr = os::memory::global::lock<const DROPFILES*>(DropHandle);
-		if (!DropPtr)
-		{
-			LOGWARNING(L"global::lock(): {}"sv, last_error());
-			return false;
-		}
+    const auto DropPtr = os::memory::global::lock<const DROPFILES*>(DropHandle);
+    if (!DropPtr)
+    {
+      LOGWARNING(L"global::lock(): {}"sv, last_error());
+      return false;
+    }
 
-		const auto HandleSize = GlobalSize(DropHandle);
+    const auto HandleSize = GlobalSize(DropHandle);
 
-		const auto Drop = view_as_opt<DROPFILES>(DropPtr.get(), HandleSize);
-		if (!Drop)
-		{
-			LOGWARNING(L"Insufficient data"sv);
-			return false;
-		}
+    const auto Drop = view_as_opt<DROPFILES>(DropPtr.get(), HandleSize);
+    if (!Drop)
+    {
+      LOGWARNING(L"Insufficient data"sv);
+      return false;
+    }
 
-		const auto Copy = Drop->fWide? copy_strings<wchar_t> : copy_strings<char>;
+    const auto Copy = Drop->fWide? copy_strings<wchar_t> : copy_strings<char>;
 
-		return Copy(data, Drop, HandleSize);
-	}
+    return Copy(data, Drop, HandleSize);
+  }
 
-	bool SetData(unsigned const Format, os::memory::global::ptr&& Data) const
-	{
-		assert(m_Opened);
+  bool SetData(unsigned const Format, os::memory::global::ptr&& Data) const
+  {
+    assert(m_Opened);
 
-		if (!SetClipboardData(Format, Data.get()))
-		{
-			LOGWARNING(L"SetClipboardData(): {}"sv, last_error());
-			return false;
-		}
+    if (!SetClipboardData(Format, Data.get()))
+    {
+      LOGWARNING(L"SetClipboardData(): {}"sv, last_error());
+      return false;
+    }
 
-		// Owned by the OS now
-		(void)Data.release();
+    // Owned by the OS now
+    (void)Data.release();
 
-		return true;
-	}
+    return true;
+  }
 
-	static unsigned RegisterFormat(clipboard_format Format)
-	{
-		static std::pair<const wchar_t*, unsigned> FormatNames[]
-		{
-			{ L"FAR_VerticalBlock", 0 },
-			{ L"FAR_VerticalBlock_Unicode", 0 },
-			{ CFSTR_PREFERREDDROPEFFECT, 0 },
-			{ L"MSDEVColumnSelect", 0 },
-			{ L"Borland IDE Block Type", 0 },
-			{ L"Notepad++ binary text length", 0 },
-		};
+  static unsigned RegisterFormat(clipboard_format Format)
+  {
+    static std::pair<const wchar_t*, unsigned> FormatNames[]
+    {
+      { L"FAR_VerticalBlock", 0 },
+      { L"FAR_VerticalBlock_Unicode", 0 },
+      { CFSTR_PREFERREDDROPEFFECT, 0 },
+      { L"MSDEVColumnSelect", 0 },
+      { L"Borland IDE Block Type", 0 },
+      { L"Notepad++ binary text length", 0 },
+    };
 
-		static_assert(std::size(FormatNames) == static_cast<size_t>(clipboard_format::count));
-		assert(Format < clipboard_format::count);
-		auto& [FormatName, FormatId] = FormatNames[static_cast<unsigned>(Format)];
-		if (!FormatId)
-		{
-			FormatId = RegisterClipboardFormat(FormatName);
-			if (!FormatId)
-			{
-				LOGWARNING(L"RegisterClipboardFormat(): {}"sv, last_error());
-			}
-		}
-		return FormatId;
-	}
+    static_assert(std::size(FormatNames) == static_cast<size_t>(clipboard_format::count));
+    assert(Format < clipboard_format::count);
+    auto& [FormatName, FormatId] = FormatNames[static_cast<unsigned>(Format)];
+    if (!FormatId)
+    {
+      FormatId = RegisterClipboardFormat(FormatName);
+      if (!FormatId)
+      {
+        LOGWARNING(L"RegisterClipboardFormat(): {}"sv, last_error());
+      }
+    }
+    return FormatId;
+  }
 
-	static bool IsFormatAvailable(unsigned Format)
-	{
-		return Format && IsClipboardFormatAvailable(Format);
-	}
+  static bool IsFormatAvailable(unsigned Format)
+  {
+    return Format && IsClipboardFormatAvailable(Format);
+  }
 };
 
 //-----------------------------------------------------------------------------
 class internal_clipboard final: public clipboard, public singleton<internal_clipboard>
 {
-	IMPLEMENTS_SINGLETON;
+  IMPLEMENTS_SINGLETON;
 
 public:
-	static auto CreateInstance()
-	{
-		return std::unique_ptr<clipboard>(new internal_clipboard);
-	}
+  static auto CreateInstance()
+  {
+    return std::unique_ptr<clipboard>(new internal_clipboard);
+  }
 
-	~internal_clipboard() override
-	{
-		internal_clipboard::Close();
-	}
+  ~internal_clipboard() override
+  {
+    internal_clipboard::Close();
+  }
 
-	bool Open() override
-	{
-		assert(!m_Opened);
+  bool Open() override
+  {
+    assert(!m_Opened);
 
-		if (m_Opened)
-			return false;
+    if (m_Opened)
+      return false;
 
-		m_Opened = true;
-		return true;
-	}
+    m_Opened = true;
+    return true;
+  }
 
-	bool Close() noexcept override
-	{
-		// Closing already closed buffer is OK
-		m_Opened = false;
-		return true;
-	}
+  bool Close() noexcept override
+  {
+    // Closing already closed buffer is OK
+    m_Opened = false;
+    return true;
+  }
 
-	bool Clear() override
-	{
-		assert(m_Opened);
+  bool Clear() override
+  {
+    assert(m_Opened);
 
-		if (!m_Opened)
-			return false;
+    if (!m_Opened)
+      return false;
 
-		m_Data.reset();
-		return true;
-	}
+    m_Data.reset();
+    return true;
+  }
 
-	bool SetText(string_view Str) override
-	{
-		assert(m_Opened);
+  bool SetText(string_view Str) override
+  {
+    assert(m_Opened);
 
-		if (!m_Opened)
-			return false;
+    if (!m_Opened)
+      return false;
 
-		m_Data = Str;
-		m_Vertical = false;
+    m_Data = Str;
+    m_Vertical = false;
 
-		return true;
-	}
+    return true;
+  }
 
-	bool SetVText(string_view Str) override
-	{
-		assert(m_Opened);
+  bool SetVText(string_view Str) override
+  {
+    assert(m_Opened);
 
-		if (!m_Opened)
-			return false;
+    if (!m_Opened)
+      return false;
 
-		m_Data = Str;
-		m_Vertical = true;
+    m_Data = Str;
+    m_Vertical = true;
 
-		return true;
-	}
+    return true;
+  }
 
-	bool SetHDROP(string_view NamesData, bool Moved) override
-	{
-		return false;
-	}
+  bool SetHDROP(string_view NamesData, bool Moved) override
+  {
+    return false;
+  }
 
-	bool GetText(string& Data) const override
-	{
-		assert(m_Opened);
+  bool GetText(string& Data) const override
+  {
+    assert(m_Opened);
 
-		if (!m_Opened)
-			return false;
+    if (!m_Opened)
+      return false;
 
-		if (!m_Data)
-			return false;
+    if (!m_Data)
+      return false;
 
-		Data = *m_Data;
-		return true;
-	}
+    Data = *m_Data;
+    return true;
+  }
 
-	bool GetVText(string& Data) const override
-	{
-		assert(m_Opened);
+  bool GetVText(string& Data) const override
+  {
+    assert(m_Opened);
 
-		if (!m_Opened)
-			return false;
+    if (!m_Opened)
+      return false;
 
-		if (!m_Data)
-			return false;
+    if (!m_Data)
+      return false;
 
-		if (!m_Vertical)
-			return false;
+    if (!m_Vertical)
+      return false;
 
-		Data = *m_Data;
-		return true;
-	}
+    Data = *m_Data;
+    return true;
+  }
 
 private:
-	internal_clipboard() = default;
+  internal_clipboard() = default;
 
-	std::optional<string> m_Data;
-	bool m_Vertical;
+  std::optional<string> m_Data;
+  bool m_Vertical;
 };
 
 //-----------------------------------------------------------------------------
@@ -635,79 +687,79 @@ static thread_local clipboard* OverridenInternalClipboard;
 
 void clipboard_restorer::operator()(const clipboard* Clip) const noexcept
 {
-	OverridenInternalClipboard = nullptr;
-	delete Clip;
+  OverridenInternalClipboard = nullptr;
+  delete Clip;
 }
 
 std::unique_ptr<clipboard, clipboard_restorer> OverrideClipboard()
 {
-	auto ClipPtr = internal_clipboard::CreateInstance();
-	OverridenInternalClipboard = ClipPtr.get();
-	return std::unique_ptr<clipboard, clipboard_restorer>(ClipPtr.release());
+  auto ClipPtr = internal_clipboard::CreateInstance();
+  OverridenInternalClipboard = ClipPtr.get();
+  return std::unique_ptr<clipboard, clipboard_restorer>(ClipPtr.release());
 }
 
 clipboard& clipboard::GetInstance(clipboard_mode Mode)
 {
-	if (OverridenInternalClipboard)
-		return *OverridenInternalClipboard;
+  if (OverridenInternalClipboard)
+    return *OverridenInternalClipboard;
 
-	if (Mode == clipboard_mode::system)
-		return system_clipboard::instance();
+  if (Mode == clipboard_mode::system)
+    return system_clipboard::instance();
 
-	return internal_clipboard::instance();
+  return internal_clipboard::instance();
 }
 
 //-----------------------------------------------------------------------------
 bool SetClipboardText(const string_view Str)
 {
-	const clipboard_accessor Clip;
-	return Clip->Open() && Clip->SetText(Str);
+  const clipboard_accessor Clip;
+  return Clip->Open() && Clip->SetText(Str);
 }
 
 bool SetClipboardVText(const string_view Str)
 {
-	const clipboard_accessor Clip;
-	return Clip->Open() && Clip->SetVText(Str);
+  const clipboard_accessor Clip;
+  return Clip->Open() && Clip->SetVText(Str);
 }
 
 bool GetClipboardText(string& data)
 {
-	const clipboard_accessor Clip;
-	return Clip->Open() && Clip->GetText(data);
+  const clipboard_accessor Clip;
+  return Clip->Open() && Clip->GetText(data);
 }
 
 bool GetClipboardVText(string& data)
 {
-	const clipboard_accessor Clip;
-	return Clip->Open() && Clip->GetVText(data);
+  const clipboard_accessor Clip;
+  return Clip->Open() && Clip->GetVText(data);
 }
 
 bool ClearClipboard()
 {
-	const clipboard_accessor Clip;
-	return Clip->Open() && Clip->Clear();
+  const clipboard_accessor Clip;
+  return Clip->Open() && Clip->Clear();
 }
 
 bool ClearInternalClipboard()
 {
-	const clipboard_accessor Clip(clipboard_mode::internal);
-	return Clip->Open() && Clip->Clear();
+  const clipboard_accessor Clip(clipboard_mode::internal);
+  return Clip->Open() && Clip->Clear();
 }
 
 bool CopyData(const clipboard_accessor& From, const clipboard_accessor& To)
 {
-	string Data;
-	if (From->GetVText(Data))
-	{
-		return To->SetVText(Data);
-	}
+  string Data;
+  if (From->GetVText(Data))
+  {
+    return To->SetVText(Data);
+  }
 
-	if (From->GetText(Data))
-	{
-		return To->SetText(Data);
-	}
+  if (From->GetText(Data))
+  {
+    return To->SetText(Data);
+  }
 
-	return false;
+  return false;
 }
 
 #ifdef ENABLE_TESTS
@@ -717,97 +769,97 @@ bool CopyData(const clipboard_accessor& From, const clipboard_accessor& To)
 class clipboard_guard
 {
 public:
-	NONCOPYABLE(clipboard_guard);
+  NONCOPYABLE(clipboard_guard);
 
-	clipboard_guard()
-	{
-		const clipboard_accessor Clip(clipboard_mode::system);
-		if (!Clip->Open())
-			return;
+  clipboard_guard()
+  {
+    const clipboard_accessor Clip(clipboard_mode::system);
+    if (!Clip->Open())
+      return;
 
-		m_Data.reserve(CountClipboardFormats());
+    m_Data.reserve(CountClipboardFormats());
 
-		for (auto i = EnumClipboardFormats(0); i; i = EnumClipboardFormats(i))
-		{
-			if (i == CF_BITMAP || i == CF_ENHMETAFILE)
-				continue;
+    for (auto i = EnumClipboardFormats(0); i; i = EnumClipboardFormats(i))
+    {
+      if (i == CF_BITMAP || i == CF_ENHMETAFILE)
+        continue;
 
-			m_Data.emplace_back(i, os::memory::global::copy(GetClipboardData(i)));
-		}
-	}
+      m_Data.emplace_back(i, os::memory::global::copy(GetClipboardData(i)));
+    }
+  }
 
-	~clipboard_guard()
-	{
-		if (m_Data.empty())
-			return;
+  ~clipboard_guard()
+  {
+    if (m_Data.empty())
+      return;
 
-		const clipboard_accessor Clip(clipboard_mode::system);
-		if (!Clip->Open())
-			return;
+    const clipboard_accessor Clip(clipboard_mode::system);
+    if (!Clip->Open())
+      return;
 
-		for (auto& [Format, Data]: m_Data)
-		{
-			SetClipboardData(Format, Data.release());
-		}
-	}
+    for (auto& [Format, Data]: m_Data)
+    {
+      SetClipboardData(Format, Data.release());
+    }
+  }
 
 private:
-	std::vector<std::pair<unsigned, os::memory::global::ptr>> m_Data;
+  std::vector<std::pair<unsigned, os::memory::global::ptr>> m_Data;
 };
 
 TEST_CASE("clipboard.stream")
 {
-	SCOPED_ACTION(clipboard_guard);
+  SCOPED_ACTION(clipboard_guard);
 
-	const auto Baseline = L"\0 Comfortably Numb \0"sv;
-	string Str;
+  const auto Baseline = L"\0 Comfortably Numb \0"sv;
+  string Str;
 
-	const auto Mode = default_clipboard_mode::get();
+  const auto Mode = default_clipboard_mode::get();
 
-	const std::array Types
-	{
-		std::pair{&SetClipboardText, &GetClipboardText},
-		std::pair{&SetClipboardVText, &GetClipboardVText},
-	};
+  const std::array Types
+  {
+    std::pair{&SetClipboardText, &GetClipboardText},
+    std::pair{&SetClipboardVText, &GetClipboardVText},
+  };
 
-	for (const auto i: { clipboard_mode::system, clipboard_mode::internal })
-	{
-		default_clipboard_mode::set(i);
+  for (const auto i: { clipboard_mode::system, clipboard_mode::internal })
+  {
+    default_clipboard_mode::set(i);
 
-		for (const auto& [Set, Get]: Types)
-		{
-			REQUIRE(Set(Baseline));
-			REQUIRE(Get(Str));
-			REQUIRE(Str == Baseline);
+    for (const auto& [Set, Get]: Types)
+    {
+      REQUIRE(Set(Baseline));
+      REQUIRE(Get(Str));
+      REQUIRE(Str == Baseline);
 
-			REQUIRE(ClearClipboard());
-			REQUIRE(!Get(Str));
-		}
-	}
+      REQUIRE(ClearClipboard());
+      REQUIRE(!Get(Str));
+    }
+  }
 
-	default_clipboard_mode::set(Mode);
+  default_clipboard_mode::set(Mode);
 }
 
 TEST_CASE("clipboard.accessors")
 {
-	SCOPED_ACTION(clipboard_guard);
+  SCOPED_ACTION(clipboard_guard);
 
-	const auto Baseline = L"\0 Hey Macarena \0"sv;
-	string Str;
+  const auto Baseline = L"\0 Hey Macarena \0"sv;
+  string Str;
 
-	const clipboard_accessor
-		ClipSystem(clipboard_mode::system),
-		ClipInternal(clipboard_mode::internal);
+  const clipboard_accessor
+    ClipSystem(clipboard_mode::system),
+    ClipInternal(clipboard_mode::internal);
 
-	REQUIRE(ClipSystem->Open());
-	REQUIRE(ClipSystem->SetText(Baseline));
-	REQUIRE(ClipInternal->Open());
-	REQUIRE(CopyData(ClipSystem, ClipInternal));
-	REQUIRE(ClipSystem->Clear());
-	REQUIRE(ClipSystem->Close());
-	REQUIRE(ClipInternal->GetText(Str));
-	REQUIRE(ClipInternal->Clear());
-	REQUIRE(ClipInternal->Close());
-	REQUIRE(Str == Baseline);
+  REQUIRE(ClipSystem->Open());
+  REQUIRE(ClipSystem->SetText(Baseline));
+  REQUIRE(ClipInternal->Open());
+  REQUIRE(CopyData(ClipSystem, ClipInternal));
+  REQUIRE(ClipSystem->Clear());
+  REQUIRE(ClipSystem->Close());
+  REQUIRE(ClipInternal->GetText(Str));
+  REQUIRE(ClipInternal->Clear());
+  REQUIRE(ClipInternal->Close());
+  REQUIRE(Str == Baseline);
 }
 #endif

--- a/far/clipboard.cpp
+++ b/far/clipboard.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
 clipboard.cpp
 
 Работа с буфером обмена.
@@ -363,26 +363,26 @@ public:
 						All versions of old Borland products I know (Builder, Delphi) has it
 						but may be some exceptions exists,
 		*/
-		if (IsOldBorlandText()) {
-			//Make temp buffer for multibyte string
-			auto buff = std::make_unique<char[]>( Data.length() );
-
-			//Compress fake unicode back to multibyte
+		if (IsOldBorlandText())
+		{
+		  const auto CheckAnsiOnly = [&](auto src, int maxS) -> int
+		  {
+			int sz = 0;
+			for (sz = 0; sz < maxS && *src; src++, sz++)
+			  if ((*src & 0xFF00) != 0)
+				return 0;
+			return sz;
+		  };
+		  int sz = CheckAnsiOnly(Data.c_str(), Data.length());
+		  if (sz)
+		  {
+			auto buff = std::make_unique<char[]>(Data.length());
 			auto src = Data.c_str();
 			auto b = buff.get();
-			int sz = 0;
-			for (; *src && sz < (int)Data.length(); src++, sz++)
-			  *b++ = *src & 0xFF;
-
-			/* Little optimization bonus.
-				In originl FAR try to insert zero-length text from clipboard.
-				Iv no idea why
-			*/
-			if ( !sz ) return false;
-
-			//Create correct unicode inplace (terminating zero included)
-			sz++;
-			MultiByteToWideChar(CP_ACP, 0, buff.get(), sz, (LPWSTR)Data.c_str(), sz );
+			for (int n = 0; n < sz; b++, src++, n++)
+			  *b = *src & 0xFF;
+			MultiByteToWideChar(CP_ACP, 0, buff.get(), sz, (LPWSTR)Data.c_str(), sz);
+		  }
 		}
 
 		return true;


### PR DESCRIPTION
## Summary

Workaround for clipboard data pasted by old Borland IDE`s.

<!-- Please review the items on the PR checklist before submitting -->
## Checklist
- [x] I have followed the [contributing guidelines](https://github.com/FarGroup/FarManager/blob/master/CONTRIBUTING.md).
- [ ] I have discussed this with project maintainers: <!-- add a link to the corresponding issue / discussion / forum topic here --> <br/>

## Details

If clipboard data in UNICODE and was created by old Borland products they all have same bug: create unicode-like data in clipboard but actually its simple text in ACP codepage "expanded" to unicode by zeroes like this:
```
"text"
```
will be:
```
"t\x00e\x00x\x00t\x00\x00\x00"
```
This works as UNICODE for ansi chars but failed with any international multibyte codepages like win1251.

Solution:
 - compress original text back to MB
 - convert it to correct unicode replacing data read from clipboard

!!NOTE:

This code assumes what ANY application which put data to clipboard using borland-clipboard-flag has this bug.

All versions of old Borland products I know (Builder, Delphi) has it but may be some exceptions exists,