### PR TITLE
Fix overlapping controls in Panel settings

### DIFF
--- a/far/config.cpp
+++ b/far/config.cpp
@@ -236,9 +236,9 @@ void Options::PanelSettings()
 
 	auto& AutoUpdateEnabled = Builder.AddCheckbox(lng::MConfigAutoUpdateLimit, AutoUpdate);
 	auto& AutoUpdateLimitItem = Builder.AddIntEditField(AutoUpdateLimit, 6);
-	AutoUpdateLimitItem.Indent(4);
 	Builder.LinkFlags(AutoUpdateEnabled, AutoUpdateLimitItem, DIF_DISABLE, false);
 	Builder.AddTextBefore(AutoUpdateLimitItem, lng::MConfigAutoUpdateLimit2).Indent(4);
+	AutoUpdateLimitItem.Indent(4);
 	Builder.AddCheckbox(lng::MConfigAutoUpdateRemoteDrive, AutoUpdateRemoteDrive);
 
 	Builder.AddSeparator();


### PR DESCRIPTION
<!-- Thank you for contributing! Please follow the steps below -->

<!-- Enter a brief description of your PR here -->
## Summary
I noticed that in the Panel settings, the *"object count"* field of the *"Disable automatic panel update"* option, overlaps with its text. Since this is just a small visual glitch with a trivial fix, I directly opened this PR, and I also didn't update the version (let me know if it needs changing).

<!-- If this PR is relevant to any other issues or existing PRs, link them here --> 
## References

<!-- Please review the items on the PR checklist before submitting -->
## Checklist
- [x] I have followed the [contributing guidelines](https://github.com/FarGroup/FarManager/blob/master/CONTRIBUTING.md).
- [ ] I have discussed this with project maintainers: <!-- add a link to the corresponding issue / discussion / forum topic here --> <br/>
If not checked, I accept that this work might be rejected in favor of a different grand plan.<br/>

<!-- Enter a more detailed description of the PR and any additional comments here -->
## Details
