### PR TITLE
Propose fareditor macros to start/end selection with hotkeys/menu

### DIFF
--- a/extra/Addons/Macros/Descript.ion
+++ b/extra/Addons/Macros/Descript.ion
@@ -10,6 +10,7 @@ Edit.Notepad.lua Editor: Notepad-like shortcuts
 Edit.OpenURL.lua Editor: Open URL or UNC under cursor
 Edit.SaveAndExit.lua Editor: Save File and Exit
 Edit.SaveFile.lua Editor: Save File
+Edit.SelectionStartEnd.lua Editor: Start/end selection with separate hotkeys
 Editor.ColorWord.moon Editor: Color Word Under Cursor
 F3.lua Use internal editor as viewer
 F9DeactivateMenu.lua Use F9 to deactivate main menu

--- a/extra/Addons/Macros/Edit.SelectionStartEnd.lua
+++ b/extra/Addons/Macros/Edit.SelectionStartEnd.lua
@@ -1,0 +1,81 @@
+local F = far.Flags
+local Selection = {}
+
+Event {
+  group="EditorEvent";
+  action=function(id,Event)
+    if Event==F.EE_CLOSE then
+      Selection[id] = nil
+    end
+  end
+}
+
+local function changeBlock(x,id,CurLine,CurPos)
+  local sel = editor.GetSelection(id) or Selection[id] or {}
+  sel[x.."Line"] = CurLine
+  sel[x.."Pos"] = CurPos
+  Selection[id] = sel
+  if not sel.EndLine or not sel.StartLine then
+    return
+  end
+  local startpos, endpos
+  if sel.BlockType==F.BTYPE_COLUMN then --https://bugs.farmanager.com/view.php?id=2759
+    startpos = editor.RealToTab(id, sel.StartLine, sel.StartPos)
+    endpos = editor.RealToTab(id, sel.EndLine, sel.EndPos)
+  else
+    startpos = sel.StartPos
+    endpos = sel.EndPos
+  end
+  local width = endpos-startpos+1
+  local height = sel.EndLine-sel.StartLine+1
+  editor.Select(id, sel.BlockType or F.BTYPE_STREAM, sel.StartLine, startpos, width, height)
+end
+
+local function selectStart()
+  local info = editor.GetInfo()
+  changeBlock("Start", info.EditorID, info.CurLine, info.CurPos)
+end
+
+local function selectEnd()
+  local info = editor.GetInfo()
+  changeBlock("End", info.EditorID, info.CurLine, info.CurPos-1)
+end
+
+Macro {
+  description="Mark selection start";
+  area="Editor";
+  key="CtrlShift9";
+  action=selectStart;
+}
+
+Macro {
+  description="Mark selection end";
+  area="Editor";
+  key="CtrlShift0";
+  action=selectEnd;
+}
+
+-- Following menu items are useful when recording macros
+-- Otherwise do not include them into menu
+
+MenuItem {
+  description="[macro] Selection start &(";
+  menu="Plugins";
+  area="Editor";
+  guid="AB0E7F16-C942-4780-AD33-E8493CF66196";
+  text=function()
+    return far.MacroGetState()~=F.MACROSTATE_NOMACRO and "&( Selection start"
+  end;
+  action=selectStart;
+}
+
+MenuItem {
+  description="[macro] Selection end &)";
+  menu="Plugins";
+  area="Editor";
+  guid="6CC1CDA4-A550-48EB-BC65-DD6EE177E2E2";
+  text=function()
+    return far.MacroGetState()~=F.MACROSTATE_NOMACRO and "&) Selection end"
+  end;
+  action=selectEnd;
+}

--- a/misc/msi-installer/features.wxs
+++ b/misc/msi-installer/features.wxs
@@ -76,6 +76,7 @@
           <ComponentRef Id="Edit.OpenURL.lua" />
           <ComponentRef Id="Edit.SaveAndExit.lua" />
           <ComponentRef Id="Edit.SaveFile.lua" />
+          <ComponentRef Id="Edit.SelectionStartEnd.lua" />
           <ComponentRef Id="F3.lua" />
           <ComponentRef Id="F9DeactivateMenu.lua" />
           <ComponentRef Id="F9Table.lua" />

--- a/misc/msi-installer/files.wxs
+++ b/misc/msi-installer/files.wxs
@@ -292,6 +292,9 @@
           <Component Id="Edit.SaveFile.lua" Guid="$(var.Guid.Edit.SaveFile.lua)" Win64="$(var.Win64)">
             <File Id="Edit.SaveFile.lua" KeyPath="yes" Source="$(var.SourceDir)\Addons\Macros\Edit.SaveFile.lua" />
           </Component>
+          <Component Id="Edit.SelectionStartEnd.lua" Guid="$(var.Guid.Edit.SelectionStartEnd.lua)" Win64="$(var.Win64)">
+            <File Id="Edit.SelectionStartEnd.lua" KeyPath="yes" Source="$(var.SourceDir)\Addons\Macros\Edit.SelectionStartEnd.lua" />
+          </Component>
           <Component Id="F3.lua" Guid="$(var.Guid.F3.lua)" Win64="$(var.Win64)">
             <File Id="F3.lua" KeyPath="yes" Source="$(var.SourceDir)\Addons\Macros\F3.lua" />
           </Component>

--- a/misc/msi-installer/guids_arm64.wxi
+++ b/misc/msi-installer/guids_arm64.wxi
@@ -105,6 +105,7 @@
 <?define Guid.Edit.OpenURL.lua = "9BEBFDDF-C337-4752-90BC-5984D9C7E31E" ?>
 <?define Guid.Edit.SaveAndExit.lua = "235043E4-B707-40C0-88A7-E86D7DD231C3" ?>
 <?define Guid.Edit.SaveFile.lua = "09BF9550-1DF8-4228-824A-AD8A9341087C" ?>
+<?define Guid.Edit.SelectionStartEnd.lua = "43BBD6A1-7840-46D0-995E-5D8DC22BD50F" ?>
 <?define Guid.F3.lua = "8446410F-A125-45BD-B791-0AFCB4F69CAB" ?>
 <?define Guid.F9DeactivateMenu.lua = "683BCAC2-01C4-49F5-9E43-F3503EA36823" ?>
 <?define Guid.F9Table.lua = "600732B1-B384-45C8-BDA8-3EC08DB00A83" ?>

--- a/misc/msi-installer/guids_x64.wxi
+++ b/misc/msi-installer/guids_x64.wxi
@@ -105,6 +105,7 @@
 <?define Guid.Edit.OpenURL.lua = "CD3C7FB1-A6E7-40B4-AA15-333F14A6D7EF" ?>
 <?define Guid.Edit.SaveAndExit.lua = "CE3C86E9-DFC9-462E-A142-38566F24C54A" ?>
 <?define Guid.Edit.SaveFile.lua = "AD682164-EFAB-42BA-9643-DBBE07170964" ?>
+<?define Guid.Edit.SelectionStartEnd.lua = "814AA0D0-113A-4797-8F95-19A8F307F776" ?>
 <?define Guid.F3.lua = "283D34FE-6E3F-4532-8A2D-CCB405A98925" ?>
 <?define Guid.F9DeactivateMenu.lua = "BC84919C-2913-4FBE-BE29-FE4279B4E89D" ?>
 <?define Guid.F9Table.lua = "4BDDEF71-86F7-4BDB-B5DC-F89056992637" ?>

--- a/misc/msi-installer/guids_x86.wxi
+++ b/misc/msi-installer/guids_x86.wxi
@@ -105,6 +105,7 @@
 <?define Guid.Edit.OpenURL.lua = "A999F555-BDBF-4133-B121-C81141EDEB21" ?>
 <?define Guid.Edit.SaveAndExit.lua = "469711CD-9306-4A66-B2B3-AE91770CA909" ?>
 <?define Guid.Edit.SaveFile.lua = "0FAE2BC2-9A43-436B-A5EC-D0853511EE75" ?>
+<?define Guid.Edit.SelectionStartEnd.lua = "7EAE2FFF-EA99-4B2A-908A-A76811BD434C" ?>
 <?define Guid.F3.lua = "022A1CFE-CD76-4FC6-B2AB-4FA17515CE17" ?>
 <?define Guid.F9DeactivateMenu.lua = "724E2805-A1C0-4B5C-91E8-60DC324BE58C" ?>
 <?define Guid.F9Table.lua = "B3A35AC7-0CE1-4871-B9C1-924D3D66E1ED" ?>


### PR DESCRIPTION
## Summary
Add FarEditor macro to mark selection start/stop using Ctrl+( or Ctrl+).
Also these actions available from menu which allows user to use them during macro recording (Ctrl+.)
If persistent blocks are enabled and you have active selection, macros automatically detect selection type (lines/blocks) and change existing selection end or start position.

## References
It is no bug/issue.

## Checklist
This was discussed several times in semiofficial telegram channel, also we have few topics on Forum with Macros, but as it is not a part of main FAR code, there were no official discussion.

Nevertheless macros can be very useful for different purposes. common usecase example:
Ctrl+(  F7(find something including using regexp for findings) Ctrl+) Ctrl+C

<!-- Enter a more detailed description of the PR and any additional comments here -->
## Details
If you want to reject this one, kindly spend 5 minutes and try to use this macro to understand how useful it can be. Thank you