### PR TITLE
Fixed bug with getting struct size PluginInfo using sizeof()

### DIFF
--- a/plugins/align/Align.cpp
+++ b/plugins/align/Align.cpp
@@ -43,7 +43,7 @@ void WINAPI SetStartupInfoW(const PluginStartupInfo *Info)
 
 void WINAPI GetPluginInfoW(PluginInfo *Info)
 {
-  Info->StructSize=sizeof(Info);
+  Info->StructSize=sizeof(*Info);
   Info->Flags=PF_EDITOR|PF_DISABLEPANELS;
   static const wchar_t *PluginMenuStrings[1];
   PluginMenuStrings[0]=GetMsg(MAlign);


### PR DESCRIPTION
<!-- Thank you for contributing! Please follow the steps below -->

<!-- Enter a brief description of your PR here -->
## Summary

Looking at name StructSize class member, it was implied by size structure itself, not pointer.

<!-- If this PR is relevant to any other issues or existing PRs, link them here --> 
## References

https://www.codeproject.com/Questions/1249365/How-can-I-check-size-of-pointer-variable-in-Cplusp