### PR TITLE
Simplify Enc building scripts

### DIFF
--- a/enc/tools/tool.make_chm.py
+++ b/enc/tools/tool.make_chm.py
@@ -83,11 +83,11 @@ def make_chm_lang(lang):
   for root, dirs, files in walk(chm_meta_dir):
     for f in files:
       infile  = open(join(root, f), encoding="utf-8-sig")
-      outfile = open(join(root.replace(chm_meta_dir, chm_html_dir), f), "w", encoding="windows-1251")
+      outfile = open(join(root.replace(chm_meta_dir, chm_html_dir), f), "w", encoding="utf-8-sig")
       header_replaced = False
       for line in infile:
         if not header_replaced and header_match in line:
-          line = line.replace(header_match, header_replace)
+          #line = line.replace(header_match, header_replace)
           header_replaced = True
 
         #while link_match.search(line):
@@ -126,7 +126,7 @@ def make_chm_lang(lang):
 
 """)
   in_hhc1 = 0
-  f1 = open(join(chm_html_dir, "index.html"), encoding="windows-1251")
+  f1 = open(join(chm_html_dir, "index.html"), encoding="utf-8-sig")
   log("Scanning %s" % f1.name)
   for l1 in f1:
     if (l1.find("HHC") != -1):
@@ -149,7 +149,7 @@ def make_chm_lang(lang):
       in_hhc2 = 0
       in_h3 = 0
       in_link = 0
-      f2 = open(join(chm_html_dir, rl[1]), encoding="windows-1251")
+      f2 = open(join(chm_html_dir, rl[1]), encoding="utf-8-sig")
       log("Scanning %s" % f2.name)
       for l2 in f2:
         if (l2.find("HHC") != -1):
@@ -224,7 +224,7 @@ def make_chm_lang(lang):
       if not fn.endswith(".html") or fn in ["faq.html"]:
         continue
       relflink = join(root[root.find("html"):], fn).replace('\\', '/')
-      f = open(join(root, fn), encoding="windows-1251")
+      f = open(join(root, fn), encoding="utf-8-sig")
       for line in f:
         if not macro_flag:
           target_list = title_list

--- a/enc/tools/tool.make_chm.py
+++ b/enc/tools/tool.make_chm.py
@@ -17,7 +17,7 @@ Make projects files for building Far Manager Encyclopedia in .CHM format
 
 from config import *
 
-from os import makedirs, walk, listdir
+from os import makedirs, walk, listdir, rename
 from os.path import isdir, join, exists
 from string import Template
 import shutil
@@ -55,52 +55,8 @@ def make_chm_lang(lang):
   copytree("%s/enc_%s" % (ROOT_DIR, lang), "%s/%s" % (DEST_CHM, lang_code))
 
   chm_lang_dir = join(DEST_CHM, lang_code)
-  makedirs(join(chm_lang_dir, "html"))
-
-  # build empty directory tree
-  chm_meta_dir = join(chm_lang_dir, "meta")
   chm_html_dir = join(chm_lang_dir, "html")
-  for root, dirs, files in walk(chm_meta_dir):
-    for d in dirs:
-      makedirs(join(root.replace(chm_meta_dir, chm_html_dir), d))
-
-  log("-- translating meta into html")
-  # filter files and replace "win32/.." links with calls to MSDN
-  link_match = re.compile(r'href[\s"\'=\/\.]*?win32\/(?P<funcname>[^"\']*?)(\.html)?[\'"].*?>(?P<linkend>.*?<\/a>)', re.I)
-  link_replace = Template(
-'''href="JavaScript:link$id.Click()">\g<linkend>
-<object id="link$id" type="application/x-oleobject" classid="clsid:adb880a6-d8ff-11cf-9377-00aa003b7a11">
-<param name="Command" value="KLink">
-<param name="DefaultTopic" value="">
-<param name="Item1" value="">
-<param name="Item2" value="\g<funcname>">
-</object>''')
-
-  header_match = '<meta http-equiv="Content-Type" Content="text/html; charset=utf-8">'
-  header_replace = '<meta http-equiv="Content-Type" Content="text/html; charset=Windows-1251">'
-
-  id = 0
-  for root, dirs, files in walk(chm_meta_dir):
-    for f in files:
-      infile  = open(join(root, f), encoding="utf-8-sig")
-      outfile = open(join(root.replace(chm_meta_dir, chm_html_dir), f), "w", encoding="utf-8-sig")
-      header_replaced = False
-      for line in infile:
-        if not header_replaced and header_match in line:
-          #line = line.replace(header_match, header_replace)
-          header_replaced = True
-
-        #while link_match.search(line):
-        #  line = link_match.sub(link_replace.substitute(id=id), line)
-        #  id += 1
-
-        outfile.write(line)
-      infile.close()
-      outfile.close()
-  log("total %d win32 links" % id)
-
-  log("-- cleaning meta")
-  shutil.rmtree(chm_meta_dir)
+  rename(join(chm_lang_dir, "meta"), chm_html_dir)
 
   log("-- creating CHM contents")
   contents_filename = join(chm_lang_dir, "plugins%s.hhc" % lang[0])


### PR DESCRIPTION
Unify inet/chm versions of Encyclopedia *.html.
(Continuation of #708)

As I found, for chm cp1251 is required for `pluginsr.hhc` and `pluginsr.hhk` only.
*.html can be in utf-8, same as for web version.
Thus we do not need to have 2 different sets of *.html
