### PR TITLE
LuaMacro: mf.GetPersistent

### DIFF
--- a/plugins/luamacro/api.lua
+++ b/plugins/luamacro/api.lua
@@ -623,6 +623,17 @@ function mf.printconsole(...)
   end
   panel.SetUserScreen()
 end
+
+local Persistent = {}
+function mf.GetPersistent(field)
+  assert(type(field)=="string", "arg #1 must be a string")
+  local t = Persistent[field]
+  if t == nil then
+    t = {}
+    Persistent[field] = t
+  end
+  return t
+end
 --------------------------------------------------------------------------------
 
 _G.band, _G.bnot, _G.bor, _G.bxor, _G.lshift, _G.rshift =


### PR DESCRIPTION
by Shmuel: https://github.com/shmuz/far2m/commit/a8f5778d2fc4031af27a04097a2501359cc709b9

data = mf.GetPersistent (strkey)

**Parameters:**
  strkey: string

**Returns:**
  data: table

**Description:**
  `GetPersistent` returns a table that is created initially empty
  by the plugin. This table may be used by macros, event handlers, etc.
  for keeping data that should not be affected by reloading macrofiles.
  The returned tables have a one—to—one correspondence with `strkey`
  argument values .

**Example:**
```
  local data = mf.Getpersistent ("ED32D2 91-C69C-4111-BBBA-277DE00887D9")
```
