### PR TITLE
Add Bypass system cache option to Copy/Move dialog

### DIFF
--- a/far/config.cpp
+++ b/far/config.cpp
@@ -2015,6 +2015,7 @@ void Options::InitConfigsData()
 		{FSSF_PRIVATE,           NKeySystem,                 L"CmdHistoryRule"sv,                CmdHistoryRule, false},
 		{FSSF_PRIVATE,           NKeySystem,                 L"ConsoleDetachKey"sv,              ConsoleDetachKey, L"CtrlShiftTab"sv},
 		{FSSF_PRIVATE,           NKeySystem,                 L"CopyBufferSize"sv,                CMOpt.BufferSize, 0},
+		{FSSF_PRIVATE,           NKeySystem,                 L"SystemCopyNoBufferingMinSize"sv,  CMOpt.SystemCopyNoBufferingMinSize, 1048576},
 		{FSSF_SYSTEM,            NKeySystem,                 L"CopyOpened"sv,                    CMOpt.CopyOpened, true},
 		{FSSF_PRIVATE,           NKeySystem,                 L"CopyTimeRule"sv,                  CMOpt.CopyTimeRule, 3},
 		{FSSF_PRIVATE,           NKeySystem,                 L"CopySecurityOptions"sv,           CMOpt.CopySecurityOptions, 0},

--- a/far/config.hpp
+++ b/far/config.hpp
@@ -741,6 +741,7 @@ public:
 		IntOption CopySecurityOptions; // для операции Move - что делать с опцией "Copy access rights"
 		IntOption CopyTimeRule;          // $ 30.01.2001 VVM  Показывает время копирования,оставшееся время и среднюю скорость
 		IntOption BufferSize;
+		IntOption SystemCopyNoBufferingMinSize; // минимальная длина файла для которого можно включить COPY_FILE_NO_BUFFERING
 	};
 
 	struct DeleteOptions

--- a/far/copy.cpp
+++ b/far/copy.cpp
@@ -168,6 +168,7 @@ private:
 	std::unique_ptr<copy_progress> CP;
 	std::unique_ptr<multifilter> m_Filter;
 	DWORD Flags;
+	DWORD SystemCopyNoBufferingMinSize;
 	panel_ptr SrcPanel, DestPanel;
 	panel_mode SrcPanelMode, DestPanelMode;
 	int SrcDriveType{}, DestDriveType{};
@@ -236,6 +237,7 @@ enum COPY_FLAGS
 	FCOPY_USESYSTEMCOPY           = 10_bit, // использовать системную функцию копирования
 	FCOPY_COPYLASTTIME            = 11_bit, // При копировании в несколько каталогов устанавливается для последнего.
 	FCOPY_UPDATEPPANEL            = 12_bit, // необходимо обновить пассивную панель
+	FCOPY_COPY_FILE_NO_BUFFERING  = 13_bit, // дополнение для системной функции копирования больших файлов
 };
 
 template<typename times_type>
@@ -294,6 +296,9 @@ enum enumShellCopy
 	IS_SC_PRESERVETIMESTAMPS,
 	ID_SC_COPYSYMLINK,
 	ID_SC_MULTITARGET,
+	ID_SC_SYSTEM_COPY_FILE_NO_BUFFERING,
+	ID_SC_SYSTEM_COPY_FILE_NO_BUFFERING_MIN_SIZE,
+	ID_SC_SYSTEM_COPY_FILE_NO_BUFFERING_MIN_SIZE_TITLE,
 	ID_SC_SEPARATOR3,
 	ID_SC_USEFILTER,
 	ID_SC_SEPARATOR4,
@@ -645,9 +650,11 @@ ShellCopy::ShellCopy(
 	// ***********************************************************************
 	// *** Prepare Dialog Controls
 	// ***********************************************************************
-	int DlgW = 76, DlgH = 17;
+	int DlgW = 76, DlgH = 17 + 1;
 
 	FARDIALOGITEMFLAGS no_tree = Global->Opt->Tree.TurnOffCompletely ? DIF_HIDDEN|DIF_DISABLE : 0;
+
+	int posFix = (int)(msg(lng::MCopySystemCopyNoBuffering).length() + 9);
 
 	auto CopyDlg = MakeDialogItems<ID_SC_COUNT>(
 	{
@@ -665,13 +672,18 @@ ShellCopy::ShellCopy(
 		{ DI_CHECKBOX,     {{5,  8 }, {0,  8 }}, DIF_NONE, msg(lng::MCopyPreserveAllTimestamps), },
 		{ DI_CHECKBOX,     {{5,  9 }, {0,  9 }}, DIF_NONE, msg(lng::MCopySymLinkContents), },
 		{ DI_CHECKBOX,     {{5,  10}, {0,  10}}, DIF_NONE, msg(lng::MCopyMultiActions), },
-		{ DI_TEXT,         {{-1, 11}, {0,  11}}, DIF_SEPARATOR, },
-		{ DI_CHECKBOX,     {{5,  12}, {0,  12}}, DIF_AUTOMATION, msg(lng::MCopyUseFilter), },
-		{ DI_TEXT,         {{-1, 13}, {0,  13}}, DIF_SEPARATOR, },
-		{ DI_BUTTON,       {{0,  14}, {0,  14}}, DIF_CENTERGROUP | DIF_DEFAULTBUTTON, msg(lng::MCopyDlgCopy), },
-		{ DI_BUTTON,       {{0,  14}, {0,  14}}, DIF_CENTERGROUP | DIF_BTNNOCLOSE | no_tree, msg(lng::MCopyDlgTree), },
-		{ DI_BUTTON,       {{0,  14}, {0,  14}}, DIF_CENTERGROUP | DIF_BTNNOCLOSE | DIF_AUTOMATION | (m_UseFilter ? DIF_NONE : DIF_DISABLE), msg(lng::MCopySetFilter), },
-		{ DI_BUTTON,       {{0,  14}, {0,  14}}, DIF_CENTERGROUP, msg(lng::MCopyDlgCancel), },
+
+		{ DI_CHECKBOX,     {{5,  11}, {0,  11}}, DIF_AUTOMATION, msg(lng::MCopySystemCopyNoBuffering), },
+		{ DI_FIXEDIT,      {{posFix, 11}, {posFix + 3, 11}}, DIF_MASKEDIT | DIF_AUTOMATION | DIF_DISABLE, L""},
+		{ DI_TEXT,         {{posFix + 5, 11}, {0,  11}}, DIF_NONE, L"MB", },
+
+		{ DI_TEXT,         {{-1, 12}, {0,  12}}, DIF_SEPARATOR, },
+		{ DI_CHECKBOX,     {{5,  13}, {0,  13}}, DIF_AUTOMATION, msg(lng::MCopyUseFilter), },
+		{ DI_TEXT,         {{-1, 14}, {0,  14}}, DIF_SEPARATOR, },
+		{ DI_BUTTON,       {{0,  15}, {0,  15}}, DIF_CENTERGROUP | DIF_DEFAULTBUTTON, msg(lng::MCopyDlgCopy), },
+		{ DI_BUTTON,       {{0,  15}, {0,  15}}, DIF_CENTERGROUP | DIF_BTNNOCLOSE | no_tree, msg(lng::MCopyDlgTree), },
+		{ DI_BUTTON,       {{0,  15}, {0,  15}}, DIF_CENTERGROUP | DIF_BTNNOCLOSE | DIF_AUTOMATION | (m_UseFilter ? DIF_NONE : DIF_DISABLE), msg(lng::MCopySetFilter), },
+		{ DI_BUTTON,       {{0,  15}, {0,  15}}, DIF_CENTERGROUP, msg(lng::MCopyDlgCancel), },
 	});
 
 	CopyDlg[ID_SC_TARGETEDIT].strHistory = L"Copy"sv;
@@ -693,6 +705,18 @@ ShellCopy::ShellCopy(
 			CopyDlg[ID_SC_SECURITY_INHERIT].X1 = CopyDlg[ID_SC_SECURITY_COPY].X1 + Str.size() - (contains(Str, L'&')? 1 : 0) + 5;
 		}
 	}
+
+	CopyDlg[ID_SC_SYSTEM_COPY_FILE_NO_BUFFERING].Selected = 0;
+
+	if (!Global->Opt->CMOpt.UseSystemCopy)
+	{
+		CopyDlg[ID_SC_SYSTEM_COPY_FILE_NO_BUFFERING].Flags |= DIF_DISABLE;
+		CopyDlg[ID_SC_SYSTEM_COPY_FILE_NO_BUFFERING_MIN_SIZE_TITLE].Flags |= DIF_DISABLE;
+	}
+
+	SystemCopyNoBufferingMinSize = Global->Opt->CMOpt.SystemCopyNoBufferingMinSize.Get();
+	// for Dlg size in MB
+	CopyDlg[ID_SC_SYSTEM_COPY_FILE_NO_BUFFERING_MIN_SIZE].strData = str(SystemCopyNoBufferingMinSize / 1048576UL);
 
 	if (Link)
 	{
@@ -975,7 +999,8 @@ ShellCopy::ShellCopy(
 		Dlg->SetId(Link?HardSymLinkId:(Move?(CurrentOnly?MoveCurrentOnlyFileId:MoveFilesId):(CurrentOnly?CopyCurrentOnlyFileId:CopyFilesId)));
 		Dlg->SetPosition({ -1, -1, DlgW, DlgH });
 		Dlg->SetAutomation(ID_SC_USEFILTER,ID_SC_BTNFILTER,DIF_DISABLE,DIF_NONE,DIF_NONE,DIF_DISABLE);
-//    Dlg->Show();
+		Dlg->SetAutomation(ID_SC_SYSTEM_COPY_FILE_NO_BUFFERING, ID_SC_SYSTEM_COPY_FILE_NO_BUFFERING_MIN_SIZE, DIF_DISABLE, DIF_NONE, DIF_NONE, DIF_DISABLE);
+		//    Dlg->Show();
 		// $ 02.06.2001 IS + Проверим список целей и поднимем тревогу, если он содержит ошибки
 		int DlgExitCode;
 
@@ -999,6 +1024,16 @@ ShellCopy::ShellCopy(
 					strCopyDlgValue = os::env::expand(strCopyDlgValue);
 
 				Global->Opt->CMOpt.PreserveTimestamps = CopyDlg[IS_SC_PRESERVETIMESTAMPS].Selected == BSTATE_CHECKED;
+
+				if (CopyDlg[ID_SC_SYSTEM_COPY_FILE_NO_BUFFERING].Selected == BSTATE_CHECKED)
+				{
+					if (Global->Opt->CMOpt.SystemCopyNoBufferingMinSize.TryParse(CopyDlg[ID_SC_SYSTEM_COPY_FILE_NO_BUFFERING_MIN_SIZE].strData))
+					{
+						// from Dlg size in MB
+						SystemCopyNoBufferingMinSize = Global->Opt->CMOpt.SystemCopyNoBufferingMinSize.Get() * 1048576UL;
+						Global->Opt->CMOpt.SystemCopyNoBufferingMinSize.Set(SystemCopyNoBufferingMinSize);
+					}
+				}
 
 				if(!Move)
 				{
@@ -1144,6 +1179,7 @@ ShellCopy::ShellCopy(
 	}
 
 	Flags|=CopyDlg[ID_SC_COPYSYMLINK].Selected? FCOPY_COPYSYMLINKCONTENTS : FCOPY_NONE;
+	Flags|= CopyDlg[ID_SC_SYSTEM_COPY_FILE_NO_BUFFERING].Selected? FCOPY_COPY_FILE_NO_BUFFERING : FCOPY_NONE;
 
 	if (DestPlugin && CopyDlg[ID_SC_TARGETEDIT].strData == strInitDestDir)
 	{
@@ -3327,7 +3363,14 @@ bool ShellCopy::ShellSystemCopy(const string_view SrcName, const string_view Des
 
 	const auto sd = GetSecurity(SrcName);
 
-	if (!os::fs::copy_file(SrcName, DestName, callback, {}, Flags & FCOPY_DECRYPTED_DESTINATION? COPY_FILE_ALLOW_DECRYPTED_DESTINATION : 0))
+	auto copyFlags = Flags & FCOPY_DECRYPTED_DESTINATION ? COPY_FILE_ALLOW_DECRYPTED_DESTINATION : 0;
+	
+	if (Flags & FCOPY_COPY_FILE_NO_BUFFERING && SrcData.FileSize >= SystemCopyNoBufferingMinSize)
+	{
+		copyFlags |= COPY_FILE_NO_BUFFERING;
+	}
+
+	if (!os::fs::copy_file(SrcName, DestName, callback, {}, copyFlags))
 	{
 		rethrow_if(ExceptionPtr);
 		Flags&=~FCOPY_DECRYPTED_DESTINATION;

--- a/far/farlang.templ.m4
+++ b/far/farlang.templ.m4
@@ -4651,6 +4651,20 @@ MCopyMultiActions
 "Апр&ацоўваць некалькі імёнаў файлаў"
 upd:"Process &multiple destinations"
 
+MCopySystemCopyNoBuffering
+"Обход &системного кэша для больших файлов"
+"Bypass &system cache for large files:"
+"Bypass &system cache for large files:"
+"Bypass &system cache for large files:"
+"Bypass &system cache for large files:"
+"Bypass &system cache for large files:"
+"Bypass &system cache for large files:"
+"Bypass &system cache for large files:"
+"Bypass &system cache for large files:"
+"Bypass &system cache for large files:"
+"Bypass &system cache for large files:"
+upd:"Bypass &system cache for large files:"
+
 MCopyDlgCopy
 "&Копировать"
 "&Copy"

--- a/far/platform.fs.cpp
+++ b/far/platform.fs.cpp
@@ -1941,6 +1941,12 @@ namespace os::fs
 			return false;
 		}
 
+		if (LastError.NtError == STATUS_INVALID_PARAMETER)
+		{
+			SetLastError(ERROR_INVALID_PARAMETER);
+			return false;
+		}
+
 		if (ElevationRequired(ELEVATION_MODIFY_REQUEST)) //BUGBUG, really unknown
 			return elevation::instance().copy_file(strFrom, strTo, RoutinePtr, DataPtr, Cancel, CopyFlags);
 


### PR DESCRIPTION
<!-- Thank you for contributing! Please follow the steps below -->

<!-- Enter a brief description of your PR here -->
## Summary
Обход системного кэша при копировании/перемещении больших файлов между папками или между разными дисками

<!-- If this PR is relevant to any other issues or existing PRs, link them here --> 
## References
<!-- Please review the items on the PR checklist before submitting -->
## Checklist
- [x] I have followed the [contributing guidelines](https://github.com/FarGroup/FarManager/blob/master/CONTRIBUTING.md).
- [ ] I have discussed this with project maintainers: <!-- add a link to the corresponding issue / discussion / forum topic here --> <br/>
If not checked, I accept that this work might be rejected in favor of a different grand plan.<br/>

<!-- Enter a more detailed description of the PR and any additional comments here -->
## Details
Мне видится что будет полезным отключать системный кэш, для таких операций ( позволяет ускорить процесс по времени и исключить вытеснение пользовательских данных из системного кэша на файловых серверах)

Обход системного кэша, осуществляется через установку флага COPY_FILE_NO_BUFFERING при вызове функции CopyFileEx.

Дополнительно введен минимальный размер файла для которого данный флаг устанавливается

Заранее прошу извинить если что-то забыл указать по данному улучшению, я делаю это впервые.