### PR TITLE
Fix lto build for clang

### DIFF
--- a/far/makefile_gcc_common
+++ b/far/makefile_gcc_common
@@ -223,9 +223,11 @@ CFLAGS += \
 	-O3 \
 
 ifeq ($(USE_LTO),1)
-CFLAGS += \
-	-flto \
-	-flto-odr-type-merging \
+CFLAGS += -flto
+
+ifndef CLANG
+CFLAGS += -flto-odr-type-merging
+endif
 
 endif # USE_LTO
 


### PR DESCRIPTION
<!-- Thank you for contributing! Please follow the steps below -->

<!-- Enter a brief description of your PR here -->
## Summary
I forgot to add this check (clang has no `lto-odr-type-merging`).
<!-- If this PR is relevant to any other issues or existing PRs, link them here --> 
## References

<!-- Please review the items on the PR checklist before submitting -->
## Checklist
- [x] I have followed the [contributing guidelines](https://github.com/FarGroup/FarManager/blob/master/CONTRIBUTING.md).
- [ ] I have discussed this with project maintainers: <!-- add a link to the corresponding issue / discussion / forum topic here --> <br/>
If not checked, I accept that this work might be rejected in favor of a different grand plan.<br/>

<!-- Enter a more detailed description of the PR and any additional comments here -->
## Details
