### PR TITLE
Set of macros to swap horizontal scroll direction in Viewer, Menus, and Shell.

### DIFF
--- a/extra/Addons/Macros/Descript.ion
+++ b/extra/Addons/Macros/Descript.ion
@@ -37,6 +37,7 @@ Panel.SpaceToSelect.lua Panel: Use Space to select files
 Search.CtrlIns.lua Close Fast find and send key to panel
 ShiftBS.lua Converts the word before cursor using XLat function.
 ShiftTab.lua Shift+Tab = Ctrl+Shift+Tab
+SwapHorizontalScrollDirection.lua Panel, Viewer and Menu: Swap horizontal scroll direction
 Symlink.lua Alternative way to create symbolic links
 UppercaseFolders.lua Restore the option "Create folders in uppercase" that was removed in Far 3.0.4184
 View.CtrlUpDown.lua Viewer: Scroll screen (using keys like in editor)

--- a/extra/Addons/Macros/SwapHorizontalScrollDirection.lua
+++ b/extra/Addons/Macros/SwapHorizontalScrollDirection.lua
@@ -1,0 +1,65 @@
+local function LeftToRight()
+    Keys(mf.akey(1,1):gsub("Left", "Right"):gsub("Num4", "Num6"))
+end
+
+local function RightToLeft()
+    Keys(mf.akey(1,1):gsub("Right", "Left"):gsub("Num6", "Num4"))
+end
+
+Macro {
+  area="Viewer";
+  description="Swap horizontal scroll direction";
+  key=
+    "Left Num4 ShiftNum4"               -- Horizontal scroll in Text and Hex modes
+    .. " CtrlLeft CtrlNum4"             -- Horizontal scroll by 20 in Text mode; roll the contents in Dump and Hex modes
+    .. " MsWheelLeft AltMsWheelLeft";   -- Translates to "Left" repeated as necessary
+  action = LeftToRight;
+}
+
+Macro {
+  area="Viewer";
+  description="Swap horizontal scroll direction";
+  key=
+    "Right Num6 ShiftNum6"              -- Horizontal scroll in Text and Hex modes
+    .. " CtrlRight CtrlNum6"            -- Horizontal scroll by 20 in Text mode; roll the contents in Dump and Hex modes
+    .. " MsWheelRight AltMsWheelRight"; -- Translates to "Right" repeated as necessary
+  action = RightToLeft;
+}
+
+Macro {
+  area="Menu";
+  description="Swap horizontal scroll direction";
+  key=
+    "AltLeft AltNum4 MsWheelLeft"                   -- Horizontal scroll all items by 1 position
+    .. " CtrlAltLeft CtrlAltNum4 CtrlMsWheelLeft"   -- Horizontal scroll all items by 20 positions
+    .. " AltShiftLeft AltShiftNum4"                 -- Horizontal scroll the current item by 1 position
+    .. " CtrlShiftLeft CtrlShiftNum4";              -- Horizontal scroll the current item by 20 positions
+  action = LeftToRight;
+}
+
+Macro {
+  area="Menu";
+  description="Swap horizontal scroll direction";
+  key=
+    "AltRight AltNum6 MsWheelRight"                 -- Horizontal scroll all items by 1 position
+    .. " CtrlAltRight CtrlAltNum6 CtrlMsWheelRight" -- Horizontal scroll all items by 20 positions
+    .. " AltShiftRight AltShiftNum6"                -- Horizontal scroll the current item by 1 position
+    .. " CtrlShiftRight CtrlShiftNum6";             -- Horizontal scroll the current item by 20 positions
+  action = RightToLeft;
+}
+
+Macro {
+  area="Shell";
+  description="Swap horizontal scroll direction";
+  flags="EmptyCommandLine";
+  key= "AltLeft";   -- Horizontal scroll of file names and descriptions
+  action = LeftToRight;
+}
+
+Macro {
+  area="Shell";
+  description="Swap horizontal scroll direction";
+  flags="EmptyCommandLine";
+  key= "AltRight";  -- Horizontal scroll of file names and descriptions
+  action = RightToLeft;
+}

--- a/misc/msi-installer/features.wxs
+++ b/misc/msi-installer/features.wxs
@@ -103,6 +103,7 @@
           <ComponentRef Id="Search.CtrlIns.lua" />
           <ComponentRef Id="ShiftBS.lua" />
           <ComponentRef Id="ShiftTab.lua" />
+          <ComponentRef Id="SwapHorizontalScrollDirection.lua" />
           <ComponentRef Id="Symlink.lua" />
           <ComponentRef Id="UppercaseFolders.lua" />
           <ComponentRef Id="View.CtrlUpDown.lua" />

--- a/misc/msi-installer/files.wxs
+++ b/misc/msi-installer/files.wxs
@@ -376,6 +376,9 @@
           <Component Id="ShiftTab.lua" Guid="$(var.Guid.ShiftTab.lua)" Win64="$(var.Win64)">
             <File Id="ShiftTab.lua" KeyPath="yes" Source="$(var.SourceDir)\Addons\Macros\ShiftTab.lua" />
           </Component>
+          <Component Id="SwapHorizontalScrollDirection.lua" Guid="$(var.Guid.SwapHorizontalScrollDirection.lua)" Win64="$(var.Win64)">
+            <File Id="SwapHorizontalScrollDirection.lua" KeyPath="yes" Source="$(var.SourceDir)\Addons\Macros\SwapHorizontalScrollDirection.lua" />
+          </Component>
           <Component Id="Symlink.lua" Guid="$(var.Guid.Symlink.lua)" Win64="$(var.Win64)">
             <File Id="Symlink.lua" KeyPath="yes" Source="$(var.SourceDir)\Addons\Macros\Symlink.lua" />
           </Component>

--- a/misc/msi-installer/guids_arm64.wxi
+++ b/misc/msi-installer/guids_arm64.wxi
@@ -134,6 +134,7 @@
 <?define Guid.Panel.Search.CtrlIns.lua = "B9CBBDC4-B167-49CB-953C-B0B08042C93E" ?>
 <?define Guid.ShiftBS.lua = "0B71229B-261D-4127-A0D0-6419D8442899" ?>
 <?define Guid.ShiftTab.lua = "A9B2DE85-138B-4CDE-B2A8-215CBBBF7BC6" ?>
+<?define Guid.SwapHorizontalScrollDirection.lua = "3D02B97C-AA72-4171-98B0-495F3B7CA69D" ?>
 <?define Guid.Symlink.lua = "D9B253AB-303A-4261-AB14-29C6A61E3C74" ?>
 <?define Guid.UppercaseFolders.lua = "67D059B3-6345-4A0E-A364-D9DF274D311E" ?>
 <?define Guid.View.CtrlUpDown.lua = "1066C05D-0F43-4E26-AF14-80F8AB89D543" ?>

--- a/misc/msi-installer/guids_x64.wxi
+++ b/misc/msi-installer/guids_x64.wxi
@@ -134,6 +134,7 @@
 <?define Guid.Panel.Search.CtrlIns.lua = "71A09EF7-1AEF-408E-BC67-A2A011216657" ?>
 <?define Guid.ShiftBS.lua = "D9C2AB23-6DC2-408E-9192-87C2F113188C" ?>
 <?define Guid.ShiftTab.lua = "D0CE372A-263F-4DEE-B4DD-C2A2B53FD9E6" ?>
+<?define Guid.SwapHorizontalScrollDirection.lua = "0782F84D-32F3-48C7-B107-098E79473515" ?>
 <?define Guid.Symlink.lua = "4702F78F-07E1-4C55-A464-FA6598C3F649" ?>
 <?define Guid.UppercaseFolders.lua = "AA9B1595-E162-4B64-957B-20D9C23620B1" ?>
 <?define Guid.View.CtrlUpDown.lua = "20944403-38BD-481D-A82F-9359415B1394" ?>

--- a/misc/msi-installer/guids_x86.wxi
+++ b/misc/msi-installer/guids_x86.wxi
@@ -134,6 +134,7 @@
 <?define Guid.Panel.Search.CtrlIns.lua = "9A712F58-6917-4353-A80C-F0DE27A419B2" ?>
 <?define Guid.ShiftBS.lua = "638743BB-D4CE-47A5-A396-7694CAD9D02C" ?>
 <?define Guid.ShiftTab.lua = "2CBFADCC-7E55-4B8D-B2A6-24F891F3B3E2" ?>
+<?define Guid.SwapHorizontalScrollDirection.lua = "1E88CD5B-8B2E-4F67-8F8F-5CFD15F9ECCD" ?>
 <?define Guid.Symlink.lua = "161D54C6-F4C4-4AB3-ADD6-D852FEAB818F" ?>
 <?define Guid.UppercaseFolders.lua = "60239181-B882-4F76-B3CB-899A902E1604" ?>
 <?define Guid.View.CtrlUpDown.lua = "27C5A1BF-2A3C-40DB-A722-BFBC1A6FB377" ?>


### PR DESCRIPTION
When enabled, these macros change horizontal scrolling direction in the Internal Viewer, VMenu / Lists, and File Panels.

Left is Right and Right is Left.

## Summary
For a long time, I was considering the behavior of the Left and Right Arrow keys in the Viewer, `Find All` menu, and Panels literally counterintuitive. The keys move viewport, while I normally want to move the items. Even after many years, I still almost always start scrolling with the wrong key.

Let's have these macros available out of the box.

## References
The issue was tangentially discussed [here](https://github.com/FarGroup/FarManager/pull/789#issuecomment-1925385503).

<!-- Please review the items on the PR checklist before submitting -->
## Checklist
- [X] I have followed the [contributing guidelines](https://github.com/FarGroup/FarManager/blob/master/CONTRIBUTING.md).
- [ ] I have discussed this with project maintainers: <!-- add a link to the corresponding issue / discussion / forum topic here --> <br/>
If not checked, I accept that this work might be rejected in favor of a different great big ineffable plan.<br/>