### PR TITLE
Fixed a typo in help files.

### DIFF
--- a/far/FarCze.hlf.m4
+++ b/far/FarCze.hlf.m4
@@ -2889,7 +2889,7 @@ $ #Interní prohlížeč: control keys#
  The following additional keys work in #dump# and #hex# modes:
 
  #Ctrl+Left#          ^<wrap>Shift all characters (#dump# mode) or bytes (#hex# mode) to the right
-moving the last character (byte) of a row to the first positions of the next row
+moving the last character (byte) of a row to the first position of the next row
  #Ctrl+Right#         Shift all characters (#dump# mode) or bytes (#hex# mode) to the left
 moving the first character (byte) of a row to the last position of the previous row
 

--- a/far/FarEng.hlf.m4
+++ b/far/FarEng.hlf.m4
@@ -2855,7 +2855,7 @@ $ #Viewer: control keys#
  The following additional keys work in #dump# and #hex# modes:
 
  #Ctrl+Left#          ^<wrap>Shift all characters (#dump# mode) or bytes (#hex# mode) to the right
-moving the last character (byte) of a row to the first positions of the next row
+moving the last character (byte) of a row to the first position of the next row
  #Ctrl+Right#         Shift all characters (#dump# mode) or bytes (#hex# mode) to the left
 moving the first character (byte) of a row to the last position of the previous row
 

--- a/far/FarGer.hlf.m4
+++ b/far/FarGer.hlf.m4
@@ -2929,7 +2929,7 @@ $ #Interner Betrachter#
  The following additional keys work in #dump# and #hex# modes:
 
  #Ctrl+Left#          ^<wrap>Shift all characters (#dump# mode) or bytes (#hex# mode) to the right
-moving the last character (byte) of a row to the first positions of the next row
+moving the last character (byte) of a row to the first position of the next row
  #Ctrl+Right#         Shift all characters (#dump# mode) or bytes (#hex# mode) to the left
 moving the first character (byte) of a row to the last position of the previous row
 

--- a/far/FarHun.hlf.m4
+++ b/far/FarHun.hlf.m4
@@ -2938,7 +2938,7 @@ $ #Nézőke: vezérlőbillentyűk#
  The following additional keys work in #dump# and #hex# modes:
 
  #Ctrl+Left#          ^<wrap>Shift all characters (#dump# mode) or bytes (#hex# mode) to the right
-moving the last character (byte) of a row to the first positions of the next row
+moving the last character (byte) of a row to the first position of the next row
  #Ctrl+Right#         Shift all characters (#dump# mode) or bytes (#hex# mode) to the left
 moving the first character (byte) of a row to the last position of the previous row
 

--- a/far/FarPol.hlf.m4
+++ b/far/FarPol.hlf.m4
@@ -2854,7 +2854,7 @@ $ #Podgląd: sterowanie klawiszami#
  The following additional keys work in #dump# and #hex# modes:
 
  #Ctrl+Left#          ^<wrap>Shift all characters (#dump# mode) or bytes (#hex# mode) to the right
-moving the last character (byte) of a row to the first positions of the next row
+moving the last character (byte) of a row to the first position of the next row
  #Ctrl+Right#         Shift all characters (#dump# mode) or bytes (#hex# mode) to the left
 moving the first character (byte) of a row to the last position of the previous row
 

--- a/far/FarSky.hlf.m4
+++ b/far/FarSky.hlf.m4
@@ -2850,7 +2850,7 @@ $ #Zabudovaný prezerač: control keys#
  The following additional keys work in #dump# and #hex# modes:
 
  #Ctrl+Left#          ^<wrap>Shift all characters (#dump# mode) or bytes (#hex# mode) to the right
-moving the last character (byte) of a row to the first positions of the next row
+moving the last character (byte) of a row to the first position of the next row
  #Ctrl+Right#         Shift all characters (#dump# mode) or bytes (#hex# mode) to the left
 moving the first character (byte) of a row to the last position of the previous row
 

--- a/far/FarUkr.hlf.m4
+++ b/far/FarUkr.hlf.m4
@@ -2912,7 +2912,7 @@ $ #Вбудована програма перегляду#
  The following additional keys work in #dump# and #hex# modes:
 
  #Ctrl+Left#          ^<wrap>Shift all characters (#dump# mode) or bytes (#hex# mode) to the right
-moving the last character (byte) of a row to the first positions of the next row
+moving the last character (byte) of a row to the first position of the next row
  #Ctrl+Right#         Shift all characters (#dump# mode) or bytes (#hex# mode) to the left
 moving the first character (byte) of a row to the last position of the previous row
 


### PR DESCRIPTION
## Summary
The typo is reported by @fml2 [here](https://github.com/FarGroup/FarManager/commit/b977f340d5c2d303f89aad4c77066794b7218a40#r144353192).

Thank you!

<!-- Please review the items on the PR checklist before submitting -->
## Checklist
- [X] I have followed the [contributing guidelines](https://github.com/FarGroup/FarManager/blob/master/CONTRIBUTING.md).
- [ ] I have discussed this with project maintainers: <!-- add a link to the corresponding issue / discussion / forum topic here --> <br/>
If not checked, I accept that this work might be rejected in favor of a different great big ineffable plan.<br/>