### PR TITLE
Add soft failover to fast search

### DIFF
--- a/far/filelist.cpp
+++ b/far/filelist.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
 filelist.cpp
 
 Файловая панель
@@ -3690,7 +3690,7 @@ bool FileList::FindPartName(string_view const Name,int Next,int Direct)
 		NameView.remove_suffix(1);
 	}
 
-	const auto strMask = exclude_sets(NameView + L'*');
+	auto strMask = exclude_sets(NameView + L'*');
 
 	const auto Match = [&](int const I)
 	{
@@ -3710,17 +3710,24 @@ bool FileList::FindPartName(string_view const Name,int Next,int Direct)
 		return false;
 	};
 
-
-	for (int I=m_CurFile+(Next?Direct:0); I >= 0 && I < static_cast<int>(m_ListData.size()); I+=Direct)
+	//Две попытки найти нужный файл - сначала строгий поиск по началам строк, потом более мягкий по серединам строк
+	//TODO: в будущем можно добавить опцию в настройки (выполнять или не выполнять вторую попытку)
+	for (int attempt=0; attempt<2; attempt++)
 	{
-		if (Match(I))
-			return true;
-	}
+		for (int I=m_CurFile+(Next?Direct:0); I >= 0 && I < static_cast<int>(m_ListData.size()); I+=Direct)
+		{
+			if (Match(I))
+				return true;
+		}
 
-	for (int I=(Direct > 0)?0:static_cast<int>(m_ListData.size()-1); (Direct > 0) ? I < m_CurFile:I > m_CurFile; I+=Direct)
-	{
-		if (Match(I))
-			return true;
+		for (int I=(Direct > 0)?0:static_cast<int>(m_ListData.size()-1); (Direct > 0) ? I < m_CurFile:I > m_CurFile; I+=Direct)
+		{
+			if (Match(I))
+				return true;
+		}
+		//Смягчаем критерий поиска, если строгий поиск ни к чему не привёл, и повторяем попытку
+		if (!strMask.starts_with(L'*'))
+			strMask = L'*' + strMask;
 	}
 
 	return false;


### PR DESCRIPTION
## Summary
Modified filelist.cpp so that if standard fast search in file panel yields no results, a second search attempt is made by searching in the middle of filename strings.
## Details
Expanded file panel fast search functionality to also search for matches in the middle of the filename strings if search in the beginning of the filename strings was unsuccessful. This is very helpful in two scenarios:

1. When no exact match in the beginning of the filename string was found, but user would like to also find matches in the middle of the filenames.
2. When directory contains files/folders that start with characters that can't be easily entered into fast search box like '[' and '{', yet the user would like to search beyond these characters.

**Specific use case that justifies this change**
A directory containing very large number sub-directories in the following format: {12345} where 12345 is a serial number. Such directlry can't be easily searched with fast search in current version of FAR because:

1. Holding Alt key and pressing "{" key results in no response from FAR (pressing "{" key without Shift generates "[" character which is filtered out)
3. Holding Alt key and pressing Shift-"{" to truly generate "{" character also results in no response from FAR
4. So the only way to search in this situation is to hold Alt key, press any other character key to bring up the fast search window, then press Shift-"{" to enter "{" into the fast search window, and then type the rest of the characters, which is very tedious.

This pull request fixes this problem by allowing the user to directly enter characters that follow the "{" character. At the same time it does not break the standard fast search functionality because if there are strict matches in the beginning of the filename strings as per classic FAR behavior, they will be found first. New code will only resort to searching in the middle of the filename strings if the classic search was unsuccessful.