### PR TITLE
luafar & luamacro: apply __tostring to error object

### DIFF
--- a/plugins/luamacro/_globalinfo.lua
+++ b/plugins/luamacro/_globalinfo.lua
@@ -1,6 +1,6 @@
 function export.GetGlobalInfo()
   return {
-    Version       = { 3, 0, 0, 882 },
+    Version       = { 3, 0, 0, 883 },
     MinFarVersion = { 3, 0, 0, 6462 },
     Guid          = win.Uuid("4EBBEFC8-2084-4B7F-94C0-692CE136894D"),
     Title         = "LuaMacro",

--- a/plugins/luamacro/api.lua
+++ b/plugins/luamacro/api.lua
@@ -625,7 +625,11 @@ function mf.printconsole(...)
   local narg = select("#", ...)
   panel.GetUserScreen()
   for i=1,narg do
-    win.WriteConsole(select(i, ...), i<narg and "\t" or "")
+    local success, err = win.WriteConsole(select(i, ...), i<narg and "\t" or "")
+    if not success then
+      panel.SetUserScreen()
+      error(err or "error in win.WriteConsole")
+    end
   end
   panel.SetUserScreen()
 end

--- a/plugins/luamacro/changelog
+++ b/plugins/luamacro/changelog
@@ -1,3 +1,11 @@
+johnd0e 2025-06-21 15:58:44+02:00 - build 883
+
+1. LuaFAR: implement luaL_tolstring (from Lua 5.2..5.3) and make consistent use of it.
+
+2. Improve non-string errors handling; apply __tostring to error object in a safe way.
+
+3. Better errors reporting in win.WriteConsole / mf.printconsole.
+
 shmuel 2025-06-18 13:19:43+03:00 - build 882
 
 1. LuaFAR: add function far.GetPluginId().

--- a/plugins/luamacro/luafar/lf_exported.c
+++ b/plugins/luamacro/luafar/lf_exported.c
@@ -111,11 +111,13 @@ int pcall_msg(lua_State* L, int narg, int nret)
 		}
 
 		if (status2 != 0) {
-			if (lua_isstring(L, -1)) // this check prevents crashes
-				LF_Error (L, check_utf8_string(L, -1, NULL));
-			else
-				LF_Error (L, L"error object is not a string");
-			lua_pop (L, 1);
+			if (NULL == safe_luaL_tolstring(L, -1, NULL)) {
+				lua_pushstring(L, "error in error handling\n");
+				lua_insert(L, -2);
+				lua_concat(L, 2);
+			}
+			LF_Error (L, check_utf8_string(L, -1, NULL));
+			lua_pop (L, 2);
 		}
 
 		*Flags &= ~PDF_PROCESSINGERROR;

--- a/plugins/luamacro/luafar/lf_exported.c
+++ b/plugins/luamacro/luafar/lf_exported.c
@@ -112,9 +112,8 @@ int pcall_msg(lua_State* L, int narg, int nret)
 
 		if (status2 != 0) {
 			if (NULL == safe_luaL_tolstring(L, -1, NULL)) {
-				lua_pushstring(L, "error in error handling\n");
-				lua_insert(L, -2);
-				lua_concat(L, 2);
+				lua_pop(L, 1);
+				lua_pushstring(L, "error in error handling");
 			}
 			LF_Error (L, check_utf8_string(L, -1, NULL));
 			lua_pop (L, 2);

--- a/plugins/luamacro/luafar/lf_exported.c
+++ b/plugins/luamacro/luafar/lf_exported.c
@@ -111,9 +111,20 @@ int pcall_msg(lua_State* L, int narg, int nret)
 		}
 
 		if (status2 != 0) {
-			if (NULL == safe_luaL_tolstring(L, -1, NULL)) {
-				lua_pop(L, 1);
-				lua_pushstring(L, "error in error handling");
+			switch (safe__tostring_meta(L, -1))
+			{
+				case TOSTRING_NOMETA:
+					if (lua_isstring(L, -1))
+						lua_pushvalue(L, -1);
+					else
+						lua_pushfstring(L, "(error object is a %s value)", luaL_typename(L, -1));
+					break;
+				case TOSTRING_SUCCESS:
+					break;
+				case TOSTRING_ERROR:
+					lua_pop(L, 1);
+					lua_pushstring(L, "error in error handling");
+					break;
 			}
 			LF_Error (L, check_utf8_string(L, -1, NULL));
 			lua_pop (L, 2);

--- a/plugins/luamacro/luafar/lf_service.c
+++ b/plugins/luamacro/luafar/lf_service.c
@@ -5344,11 +5344,7 @@ static int far_MakeMenuItems(lua_State *L)
 			char* str;
 
 			lua_pushvalue(L, i);                   //+3
-			start = safe_luaL_tolstring(L, -1, &len_arg);
-			if (start == NULL) {
-				lua_error(L);
-			}
-
+			start = luaL_tolstring(L, -1, &len_arg);
 			sprintf(buf_prefix, "%*d%s ", maxno, i, delim);
 			str = (char*) malloc(len_arg + 1);
 			memcpy(str, start, len_arg + 1);

--- a/plugins/luamacro/luafar/lf_service.c
+++ b/plugins/luamacro/luafar/lf_service.c
@@ -2151,23 +2151,9 @@ static int far_Message(lua_State *L)
 	lua_settop(L,6);
 	Msg = NULL;
 
-	if (lua_isstring(L, 1))
-		Msg = check_utf8_string(L, 1, NULL);
-	else
-	{
-		lua_getglobal(L, "tostring");
-
-		if (lua_isfunction(L,-1))
-		{
-			lua_pushvalue(L,1);
-			lua_call(L,1,1);
-			Msg = check_utf8_string(L,-1,NULL);
-		}
-
-		if (Msg == NULL) luaL_argerror(L, 1, "cannot convert to string");
-
-		lua_replace(L,1);
-	}
+	luaL_tolstring(L, 1, NULL);
+	Msg = check_utf8_string(L, -1, NULL);
+	lua_replace(L,1);
 
 	Title   = opt_utf8_string(L, 2, L"Message");
 	Buttons = opt_utf8_string(L, 3, L";OK");

--- a/plugins/luamacro/luafar/lf_service.c
+++ b/plugins/luamacro/luafar/lf_service.c
@@ -5343,23 +5343,16 @@ static int far_MakeMenuItems(lua_State *L)
 			const char *start;
 			char* str;
 
-			lua_getglobal(L, "tostring");          //+2
-
-			if (i == 1 && lua_type(L,-1) != LUA_TFUNCTION)
-				luaL_error(L, "global `tostring' is not function");
-
 			lua_pushvalue(L, i);                   //+3
-
-			if (0 != lua_pcall(L, 1, 1, 0))         //+2 (items,str)
-				luaL_error(L, lua_tostring(L, -1));
-
-			if (lua_type(L, -1) != LUA_TSTRING)
-				luaL_error(L, "tostring() returned a non-string value");
+			start = safe_luaL_tolstring(L, -1, &len_arg);
+			if (start == NULL) {
+				lua_error(L);
+			}
 
 			sprintf(buf_prefix, "%*d%s ", maxno, i, delim);
-			start = lua_tolstring(L, -1, &len_arg);
 			str = (char*) malloc(len_arg + 1);
 			memcpy(str, start, len_arg + 1);
+			lua_pop(L, 2);                         //+1 (items)
 
 			for (j=0; j<len_arg; j++)
 				if (str[j] == '\0') str[j] = ' ';
@@ -5381,13 +5374,12 @@ static int far_MakeMenuItems(lua_State *L)
 				lua_setfield(L, -2, "text");         //+3
 				lua_pushvalue(L, i);
 				lua_setfield(L, -2, "arg");          //+3
-				lua_rawseti(L, -3, item++);          //+2 (items,str)
+				lua_rawseti(L, -2, item++);          //+2 (items,str)
 				strcpy(buf_prefix, buf_space);
 				start = nl;
 			}
 
 			free(str);
-			lua_pop(L, 1);                         //+1 (items)
 		}
 	}
 

--- a/plugins/luamacro/luafar/lf_string.c
+++ b/plugins/luamacro/luafar/lf_string.c
@@ -861,19 +861,9 @@ const wchar_t* opt_utf16_string(lua_State *L, int pos, const wchar_t *dflt)
 
 static int ustring_OutputDebugString(lua_State *L)
 {
-	if (lua_isstring(L, 1))
-		OutputDebugStringW(check_utf8_string(L, 1, NULL));
-	else
-	{
-		lua_settop(L, 1);
-		lua_getglobal(L, "tostring");
-		if (lua_isfunction(L, -1))
-		{
-			lua_pushvalue(L,  1);
-			if (0==lua_pcall(L, 1, 1, 0) && lua_isstring(L, -1))
-				OutputDebugStringW(check_utf8_string(L, -1, NULL));
-		}
-	}
+	lua_settop(L, 1);
+	luaL_tolstring(L, 1, NULL);
+	OutputDebugStringW(check_utf8_string(L, -1, NULL));
 	return 0;
 }
 

--- a/plugins/luamacro/luafar/lf_string.h
+++ b/plugins/luamacro/luafar/lf_string.h
@@ -20,6 +20,14 @@ extern "C" {
 
 LUALIB_API int luaopen_ustring(lua_State *L);
 
+typedef enum {
+    TOSTRING_ERROR   = -1,
+    TOSTRING_NOMETA  = 0,
+    TOSTRING_SUCCESS = 1
+} ToStringResult;
+
+const char *luaL_tolstring(lua_State *L, int idx, size_t *len);
+ToStringResult safe__tostring_meta(lua_State *L, int idx);
 const char *safe_luaL_tolstring(lua_State *L, int idx, size_t *len);
 void pusherrorcode(lua_State *L, int error);
 void pusherror(lua_State *L);

--- a/plugins/luamacro/luafar/lf_string.h
+++ b/plugins/luamacro/luafar/lf_string.h
@@ -20,6 +20,7 @@ extern "C" {
 
 LUALIB_API int luaopen_ustring(lua_State *L);
 
+const char *safe_luaL_tolstring(lua_State *L, int idx, size_t *len);
 void pusherrorcode(lua_State *L, int error);
 void pusherror(lua_State *L);
 int  SysErrorReturn(lua_State *L);

--- a/plugins/luamacro/luafar/lf_version.h
+++ b/plugins/luamacro/luafar/lf_version.h
@@ -1,3 +1,3 @@
 ﻿#include <farversion.hpp>
 
-#define PLUGIN_BUILD 882
+#define PLUGIN_BUILD 883

--- a/plugins/luamacro/luafar/lf_win.c
+++ b/plugins/luamacro/luafar/lf_win.c
@@ -798,12 +798,12 @@ int win_WriteConsole(lua_State *L)
 	{
 		size_t nCharsToWrite;
 		DWORD nCharsWritten;
-		lua_getglobal(L, "tostring"); //narg+1
-		if (!lua_isfunction(L, -1))
-			return 0;
 		lua_pushvalue(L, i+1); //narg+2
-		if (lua_pcall(L, 1, 1, 0) || lua_type(L, -1) != LUA_TSTRING) //narg+1
-			return 0;
+		if (NULL == safe_luaL_tolstring(L, -1, NULL)) {
+			lua_pushnil(L);
+			lua_insert(L, -2);
+			return 2;
+		}
 		check_utf8_string(L, -1, &nCharsToWrite); //narg+1
 		if (!WriteConsoleW(h_out, (const void*)lua_touserdata(L,-1), (DWORD)nCharsToWrite, &nCharsWritten, NULL))
 			return SysErrorReturn(L);

--- a/plugins/luamacro/luamacro.lua
+++ b/plugins/luamacro/luamacro.lua
@@ -206,17 +206,16 @@ end
 
 local function safe_tostring (obj)
   local success, str = pcall(tostring, obj)
-  if success then
-    if type(str)=="string" then
-      return str
-    end
-    str = string.format("(tostring returned a %s value)", type(str))
-  else
+  if not success then
     if type(str)~="string" then
       str = string.format("(error object is a %s value)", type(str))
     end
+    return nil, str
+  elseif type(str)~="string" then
+    return nil, "'__tostring' must return a string"
+  else
+    return str
   end
-  return "error calling tostring: "..str, true
 end
 
 local function FixReturn (handle, ok, ...)
@@ -230,8 +229,7 @@ local function FixReturn (handle, ok, ...)
       return F.MPRT_NORMALFINISH, pack(true, ...)
     end
   else
-    local msg,err = safe_tostring(ret1)
-    if err then msg = "error in error handling\n"..msg end
+    local msg = safe_tostring(ret1) or "error in error handling"
     msg = string.gsub(debug.traceback(handle.coro, msg), "\n\t", "\n   ")
     ErrMsg(msg)
     return F.MPRT_ERRORFINISH

--- a/plugins/luamacro/luamacro.lua
+++ b/plugins/luamacro/luamacro.lua
@@ -218,6 +218,21 @@ local function safe_tostring (obj)
   end
 end
 
+local function formatErr (obj)
+  local tname = type(obj)
+  if tname=="number" then
+    obj = tostring(obj)
+  elseif tname~="string" then
+    local mt = debug.getmetatable(obj)
+    if mt and mt.__tostring~=nil then
+      obj = safe_tostring(obj) or "error in error handling"
+    else
+      obj = string.format("(error object is a %s value)", tname)
+    end
+  end
+  return obj
+end
+
 local function FixReturn (handle, ok, ...)
   local ret1, ret_type = ...
   if ok then
@@ -229,8 +244,7 @@ local function FixReturn (handle, ok, ...)
       return F.MPRT_NORMALFINISH, pack(true, ...)
     end
   else
-    local msg = safe_tostring(ret1) or "error in error handling"
-    msg = string.gsub(debug.traceback(handle.coro, msg), "\n\t", "\n   ")
+    local msg = string.gsub(debug.traceback(handle.coro, formatErr(ret1)), "\n\t", "\n   ")
     ErrMsg(msg)
     return F.MPRT_ERRORFINISH
   end


### PR DESCRIPTION
The initial goal of the proposed changes is to correctly display error messages for objects that have a `__tostring` metamethod, which needs to be called safely to obtain the final message.
All errors that might occur during this process are handled and outputted consistently with the standard interpreter's behavior (the error text was checked against Lua 5.4).

The changes affected `pcall_msg` (in `luafar/lf_exported.c`) and `FixReturn` (in `luamacro/luamacro.lua`). Additionally, common helper functions were implemented (in `luafar/lf_string.c`):

*   `luaL_tolstring` - A copy of the function which has been [standard](https://www.lua.org/manual/5.2/manual.html#luaL_tolstring) since Lua 
5.2.
    It is used in: `far.MakeMenuItems`, `far.Message`, `win.OutputDebugString`, and `far.MakeMenuItems` (as a helper for `far.Show`). This cleaned up "copy-pasted" code in these areas and ensured consistent handling.
*   `safe__tostring_meta`: Used for error output in `pcall_msg` and is therefore protected (i.e., handles potential errors during the `__tostring` call safely).
    <details>

    ```c
    /**
     * @brief Safely calls the __tostring metamethod for a value on the Lua stack.
     *
     * Attempts to retrieve and call the __tostring metamethod for the Lua value
     * at the given stack index `idx`.
     *
     * Stack effects:
     * - If no __tostring metamethod exists: Returns 0, stack unchanged.
     * - If __tostring call succeeds and returns a string: Returns 1, leaves the
     *   resulting string on top of the stack.
     * - If __tostring call fails (errors): Returns -1, leaves an error message
     *   string on top of the stack. The original error object is replaced with
     *   a formatted string if it wasn't a string itself.
     * - If __tostring call succeeds but returns a non-string: Returns -1, leaves
     *   the error message "'__tostring' must return a string" on top of the stack.
     *
     * The original value at `idx` remains untouched on the stack below the result/error.
     *
     * @param L The Lua state.
     * @param idx The stack index of the value whose __tostring metamethod should be called.
     * @return 1 on success (string pushed),
     *         0 if no __tostring metamethod exists (stack unchanged),
     *        -1 on error (__tostring errored or returned non-string; error string pushed).
     */
    ```
    </details>

*   `safe_luaL_tolstring`: the same as the `luaL_tolstring`, but protected (uses `safe__tostring_meta` under hood).
    On error:  error message is pushed onto the stack, and NULL is returned.
    Used in `win.WriteConsole`, which allows obtaining meaningful error messages. This is used, in particular, in `mf.printconsole`: the function now no longer ignores errors during string conversion.
