### PR TITLE
gh-802: Macro: `CtrlClear` toggles menu vertical alignment between 'Found patterns' and 'Home'

### DIFF
--- a/extra/Addons/Macros/Descript.ion
+++ b/extra/Addons/Macros/Descript.ion
@@ -15,6 +15,7 @@ Editor.ColorWord.moon Editor: Color Word Under Cursor
 F3.lua Use internal editor as viewer
 F9DeactivateMenu.lua Use F9 to deactivate main menu
 F9Table.lua Use F9 to change current table in viewer and editor
+Menu.CtrlClear.lua Menu: CtrlClear toggles vertical alignment between 'All found entries' and 'Home'
 OpeningLastFile.lua Opening previous view/edit (from history)
 Panel.AltBS.lua Panel: Folders history navigation
 Panel.Apps.lua Panel: Use Apps to Change drive in current panel

--- a/extra/Addons/Macros/Menu.CtrlClear.lua
+++ b/extra/Addons/Macros/Menu.CtrlClear.lua
@@ -1,0 +1,18 @@
+Macro {
+  description="Menu: CtrlClear toggles vertical alignment between 'All found entries' and 'Home'";
+  area="Menu";
+  key="CtrlClear";
+  action = function()
+    -- Menu.HorizontalAlignment:
+    --  0 Menu items are not aligned
+    --  1 Menu items are left-aligned
+    --  2 Menu items are right-aligned
+    --  4 Menu items are aligned at annotations, i.e., the found search pattern in editor's Find All menu
+    -- -1 The active object is not a menu
+    if Menu.HorizontalAlignment == 4 then
+      Keys("AltHome")
+    else
+      Keys("CtrlClear")
+    end
+  end;
+}

--- a/misc/msi-installer/features.wxs
+++ b/misc/msi-installer/features.wxs
@@ -81,6 +81,7 @@
           <ComponentRef Id="F3.lua" />
           <ComponentRef Id="F9DeactivateMenu.lua" />
           <ComponentRef Id="F9Table.lua" />
+          <ComponentRef Id="Menu.CtrlClear.lua" />
           <ComponentRef Id="OpeningLastFile.lua" />
           <ComponentRef Id="Panel.AltBS.lua" />
           <ComponentRef Id="Panel.Apps.lua" />

--- a/misc/msi-installer/files.wxs
+++ b/misc/msi-installer/files.wxs
@@ -310,6 +310,9 @@
           <Component Id="F9Table.lua" Guid="$(var.Guid.F9Table.lua)" Win64="$(var.Win64)">
             <File Id="F9Table.lua" KeyPath="yes" Source="$(var.SourceDir)\Addons\Macros\F9Table.lua" />
           </Component>
+          <Component Id="Menu.CtrlClear.lua" Guid="$(var.Guid.Menu.CtrlClear.lua)" Win64="$(var.Win64)">
+            <File Id="Menu.CtrlClear.lua" KeyPath="yes" Source="$(var.SourceDir)\Addons\Macros\Menu.CtrlClear.lua" />
+          </Component>
           <Component Id="OpeningLastFile.lua" Guid="$(var.Guid.OpeningLastFile.lua)" Win64="$(var.Win64)">
             <File Id="OpeningLastFile.lua" KeyPath="yes" Source="$(var.SourceDir)\Addons\Macros\OpeningLastFile.lua" />
           </Component>

--- a/misc/msi-installer/guids_arm64.wxi
+++ b/misc/msi-installer/guids_arm64.wxi
@@ -113,6 +113,7 @@
 <?define Guid.F3.lua = "8446410F-A125-45BD-B791-0AFCB4F69CAB" ?>
 <?define Guid.F9DeactivateMenu.lua = "683BCAC2-01C4-49F5-9E43-F3503EA36823" ?>
 <?define Guid.F9Table.lua = "600732B1-B384-45C8-BDA8-3EC08DB00A83" ?>
+<?define Guid.Menu.CtrlClear.lua = "BFB8F991-8E66-410E-B4CF-0F2FBEDEE8A1" ?>
 <?define Guid.OpeningLastFile.lua = "D7164261-1129-455E-AB60-7D1A7304A41F" ?>
 <?define Guid.Panel.AltBS.lua = "DE1C5951-0D5F-40D8-A78E-AB57828CE3B9" ?>
 <?define Guid.Panel.Apps.lua = "7C4ADC42-5DC1-4E3B-9A45-968BC3522F1D" ?>

--- a/misc/msi-installer/guids_x64.wxi
+++ b/misc/msi-installer/guids_x64.wxi
@@ -113,6 +113,7 @@
 <?define Guid.F3.lua = "283D34FE-6E3F-4532-8A2D-CCB405A98925" ?>
 <?define Guid.F9DeactivateMenu.lua = "BC84919C-2913-4FBE-BE29-FE4279B4E89D" ?>
 <?define Guid.F9Table.lua = "4BDDEF71-86F7-4BDB-B5DC-F89056992637" ?>
+<?define Guid.Menu.CtrlClear.lua = "8F0BD12D-5917-4B3A-B9E5-301F695F790B" ?>
 <?define Guid.OpeningLastFile.lua = "F85EF120-8263-42B8-A541-CC8D1A07E057" ?>
 <?define Guid.Panel.AltBS.lua = "304ACCA0-D4C6-4DEE-BA43-1691ECD7981A" ?>
 <?define Guid.Panel.Apps.lua = "468080AC-53FC-478A-A044-25EDC97F3F07" ?>

--- a/misc/msi-installer/guids_x86.wxi
+++ b/misc/msi-installer/guids_x86.wxi
@@ -113,6 +113,7 @@
 <?define Guid.F3.lua = "022A1CFE-CD76-4FC6-B2AB-4FA17515CE17" ?>
 <?define Guid.F9DeactivateMenu.lua = "724E2805-A1C0-4B5C-91E8-60DC324BE58C" ?>
 <?define Guid.F9Table.lua = "B3A35AC7-0CE1-4871-B9C1-924D3D66E1ED" ?>
+<?define Guid.Menu.CtrlClear.lua = "E490737E-321E-4FE9-B643-1936FBB220D7" ?>
 <?define Guid.OpeningLastFile.lua = "1357DAF3-4120-48C9-82E4-1B5F64F7E57F" ?>
 <?define Guid.Panel.AltBS.lua = "5D0C8A1B-472E-4195-A529-8BD6F96423EE" ?>
 <?define Guid.Panel.Apps.lua = "21FE4362-51F0-4098-9DDE-16C1700D70BA" ?>


### PR DESCRIPTION
When enabled, this macro changes behavior of `Ctrl+Numpad5` to toggle vertical alignment of menu items between 'Found patterns' and 'Home'.

## Summary
The idea of this macro was discussed in gh-802. Supporting macro-API was implemented under gh-895 and gh-902. Tagging @rohitab.

This PR adds the requested macro, partly because of its potential value for the Far users, partly to make sure `Menu.HorizontalAlignment` implementation is not a dead code, and partly as a proxy to documentation for the API.

## References
- gh-802
- gh-895
- gh-902

<!-- Please review the items on the PR checklist before submitting -->
## Checklist
- [X] I have followed the [contributing guidelines](https://github.com/FarGroup/FarManager/blob/master/CONTRIBUTING.md).
- [X] I have discussed this with project maintainers: <!-- add a link to the corresponding issue / discussion / forum topic here --> <br/>
If not checked, I accept that this work might be rejected in favor of a different great big ineffable plan.<br/>