### PR TITLE
LuaFAR: fix FarColor / UnderlineColor handling

### DIFF
--- a/plugins/luamacro/_globalinfo.lua
+++ b/plugins/luamacro/_globalinfo.lua
@@ -1,6 +1,6 @@
 function export.GetGlobalInfo()
   return {
-    Version       = { 3, 0, 0, 873 },
+    Version       = { 3, 0, 0, 874 },
     MinFarVersion = { 3, 0, 0, 6462 },
     Guid          = win.Uuid("4EBBEFC8-2084-4B7F-94C0-692CE136894D"),
     Title         = "LuaMacro",

--- a/plugins/luamacro/changelog
+++ b/plugins/luamacro/changelog
@@ -1,3 +1,7 @@
+johnd0e 2025-04-30 23:54:19+02:00 - build 874
+
+1. LuaFAR: fix FarColor / UnderlineColor handling.
+
 shmuel 2025-04-17 10:44:36+03:00 - build 873
 
 1. LuaFAR: support named groups in regex functions.

--- a/plugins/luamacro/luafar/lf_service.c
+++ b/plugins/luamacro/luafar/lf_service.c
@@ -1406,7 +1406,7 @@ int GetFarColor(lua_State *L, int pos, struct FarColor* Color)
 		Color->Flags = CheckFlagsFromTable(L, -1, "Flags");
 		Color->Foreground.ForegroundColor = CAST(COLORREF, GetOptNumFromTable(L, "ForegroundColor", 0));
 		Color->Background.BackgroundColor = CAST(COLORREF, GetOptNumFromTable(L, "BackgroundColor", 0));
-		Color->Underline.UnderlineColor = 0;
+		Color->Underline.UnderlineColor = CAST(COLORREF, GetOptNumFromTable(L, "UnderlineColor", 0));
 		Color->Reserved = 0;
 		lua_pop(L, 1);
 		return 1;
@@ -1414,7 +1414,7 @@ int GetFarColor(lua_State *L, int pos, struct FarColor* Color)
 	else if (lua_isnumber(L, pos))
 	{
 		DWORD num = (DWORD)lua_tonumber(L, pos);
-		Color->Flags = FCF_4BITMASK;
+		Color->Flags = FCF_INDEXMASK;
 		Color->Foreground.ForegroundColor = (num & 0x0F) | ALPHAMASK;
 		Color->Background.BackgroundColor = ((num>>4) & 0x0F) | ALPHAMASK;
 		Color->Underline.UnderlineColor = 0;
@@ -1430,6 +1430,7 @@ void PushFarColor(lua_State *L, const struct FarColor* Color)
 	PutFlagsToTable(L, "Flags", Color->Flags);
 	PutNumToTable(L, "ForegroundColor", Color->Foreground.ForegroundColor);
 	PutNumToTable(L, "BackgroundColor", Color->Background.BackgroundColor);
+	PutNumToTable(L, "UnderlineColor", Color->Underline.UnderlineColor);
 }
 
 static void GetOptGuid(lua_State *L, int pos, GUID* target, const GUID* source)

--- a/plugins/luamacro/luafar/lf_version.h
+++ b/plugins/luamacro/luafar/lf_version.h
@@ -1,3 +1,3 @@
 ﻿#include <farversion.hpp>
 
-#define PLUGIN_BUILD 873
+#define PLUGIN_BUILD 874


### PR DESCRIPTION
This PR addresses a LuaFAR bug in the handling of `UnderlineColor` in the `FarColor` structure.