### PR TITLE
LuaMacro: fix edit position on moonscript parsing error

### DIFF
--- a/plugins/luamacro/utils.lua
+++ b/plugins/luamacro/utils.lua
@@ -683,7 +683,6 @@ local function ErrMsgLoad (msg, filename, isMoonScript, mode)
     if 2 == far.Message(msg, title, "OK;Edit", "wl") then
       local pattern = isMoonScript and "%[(%d+)%] >>" or "^[^\n]-:(%d+):"
       local line = tonumber(msg:match(pattern))
-      if line and isMoonScript then line = GetMoonscriptLineNumber(filename,line) end
       editor.Editor(filename,nil,nil,nil,nil,nil,nil,line or 1,nil,65001)
     end
   end


### PR DESCRIPTION
The line extracted from error message does not need correction
