### PR TITLE
LuaMacro plugin: Enable win.GetFileTimes/win.SetFileTimes to get/set change time

### DIFF
--- a/enc/enc_lua/luafar_manual.tsi
+++ b/enc/enc_lua/luafar_manual.tsi
@@ -9920,7 +9920,7 @@ lv=3
 dt=Text
 nm=win.GetFileTimes
 ctime=3790916234
-mtime=3790917671
+mtime=3968140988
 <article>
 #_times = win.GetFileTimes (FileName)
 #_
@@ -9933,12 +9933,13 @@ mtime=3790917671
 #_      LastWriteTime:      `bit64-userdata`
 #_      LastAccessTime:     `bit64-userdata`
 #_      CreationTime:       `bit64-userdata`
+#_      ChangeTime:         `bit64-userdata`
 #_
 #_**Note:**
 #_  All time values are expressed in 100-ns intervals elapsed since 1601-01-01,00:00:00.
 #_
 #_**Windows API used:**
-#_  CreateFile, GetFileTime
+#_  CreateFile, NtQueryInformationFile
 #_
 #_@@@
 #_[bit64-userdata]: 405.html
@@ -10154,7 +10155,7 @@ lv=3
 dt=Text
 nm=win.SetFileTimes
 ctime=3790916254
-mtime=3790917726
+mtime=3968141009
 <article>
 #_result = win.SetFileTimes (FileName, times)
 #_
@@ -10165,6 +10166,7 @@ mtime=3790917726
 #_      LastWriteTime:      `bit64-userdata` or number
 #_      LastAccessTime:     `bit64-userdata` or number
 #_      CreationTime:       `bit64-userdata` or number
+#_      ChangeTime:         `bit64-userdata` or number
 #_
 #_**Returns:**
 #_  result:   boolean
@@ -10173,7 +10175,7 @@ mtime=3790917726
 #_  All time values are expressed in 100-ns intervals elapsed since 1601-01-01,00:00:00.
 #_
 #_**Windows API used:**
-#_  CreateFile, SetFileTime
+#_  CreateFile, NtSetInformationFile
 #_
 #_@@@
 #_[bit64-userdata]: 405.html

--- a/plugins/luamacro/_globalinfo.lua
+++ b/plugins/luamacro/_globalinfo.lua
@@ -1,6 +1,6 @@
 function export.GetGlobalInfo()
   return {
-    Version       = { 3, 0, 0, 892 },
+    Version       = { 3, 0, 0, 893 },
     MinFarVersion = { 3, 0, 0, 6546 },
     Guid          = win.Uuid("4EBBEFC8-2084-4B7F-94C0-692CE136894D"),
     Title         = "LuaMacro",

--- a/plugins/luamacro/changelog
+++ b/plugins/luamacro/changelog
@@ -1,3 +1,7 @@
+rohitab 2025-09-27 13:33:20+10:00 - build 893
+
+1. gh-611: Enable win.GetFileTimes/win.SetFileTimes to get/set change time.
+
 shmuel 2025-09-26 10:38:38+03:00 - build 892
 
 1. LuaFAR: rename actl.Waitkey to actl.WaitKey

--- a/plugins/luamacro/luafar/lf_version.h
+++ b/plugins/luamacro/luafar/lf_version.h
@@ -1,3 +1,3 @@
 ﻿#include <farversion.hpp>
 
-#define PLUGIN_BUILD 892
+#define PLUGIN_BUILD 893


### PR DESCRIPTION
<!-- Thank you for contributing! Please follow the steps below -->

<!-- Enter a brief description of your PR here -->
## Summary
The Lua API's `win.GetFileTimes` and `win.SetFileTimes` currently allow retrieving and setting _Creation time_, _Last access time_, and _Last write time_. This PR adds support to get and set _Change time_ as well.

<!-- If this PR is relevant to any other issues or existing PRs, link them here --> 
## References
https://github.com/FarGroup/FarManager/issues/611

<!-- Please review the items on the PR checklist before submitting -->
## Checklist
- [x] I have followed the [contributing guidelines](https://github.com/FarGroup/FarManager/blob/master/CONTRIBUTING.md).
- [x] I have discussed this with project maintainers: https://github.com/FarGroup/FarManager/issues/611<br/>
If not checked, I accept that this work might be rejected in favor of a different grand plan.<br/>

<!-- Enter a more detailed description of the PR and any additional comments here -->
## Details
The functions `win.GetFileTimes` and `win.SetFileTimes` have been modified to use `NtQueryInformationFile` and `NtSetInformationFile` to get/set time. These are the same API's used by _Far_.

The API's work as before, except that the table has an additional field `ChangeTime` that can be set and retrieved. As before, `win.SetFileTimes` supports setting one, all or any combination of the available time values.