### PR TITLE
Add Editor.LineNumbers colors

### DIFF
--- a/extra/Addons/Colors/Interface/Colors_from_Gernichenko.farconfig
+++ b/extra/Addons/Colors/Interface/Colors_from_Gernichenko.farconfig
@@ -51,7 +51,7 @@
     <object name="Dialog.Text" background="FF000000" foreground="FF000007" flags="fgindex bgindex inherit"/>
     <object name="Dialog.Text.Highlight" background="FF000000" foreground="FF00000E" flags="fgindex bgindex inherit"/>
     <object name="Editor.Clock" background="FF000003" foreground="FF000000" flags="fgindex bgindex inherit"/>
-    <!-- <object name="Editor.LineNumbers" background="FF000001" foreground="FF000007" flags="fgindex bgindex ulindex inherit"/> -->
+    <object name="Editor.LineNumbers" background="FF000000" foreground="FF000007" flags="fgindex bgindex inherit"/>
     <object name="Editor.Scrollbar" background="FF000001" foreground="FF00000B" flags="fgindex bgindex inherit"/>
     <object name="Editor.Status" background="FF000003" foreground="FF000000" flags="fgindex bgindex inherit"/>
     <object name="Editor.Text" background="FF000000" foreground="FF00000B" flags="fgindex bgindex inherit"/>

--- a/extra/Addons/Colors/Interface/Colors_from_Sadovoj.farconfig
+++ b/extra/Addons/Colors/Interface/Colors_from_Sadovoj.farconfig
@@ -51,7 +51,7 @@
     <object name="Dialog.Text" background="FF000001" foreground="FF00000F" flags="fgindex bgindex inherit"/>
     <object name="Dialog.Text.Highlight" background="FF000001" foreground="FF00000B" flags="fgindex bgindex inherit"/>
     <object name="Editor.Clock" background="FF000003" foreground="FF000000" flags="fgindex bgindex inherit"/>
-    <!-- <object name="Editor.LineNumbers" background="FF000001" foreground="FF000007" flags="fgindex bgindex ulindex inherit"/> -->
+    <object name="Editor.LineNumbers" background="FF000001" foreground="FF000007" flags="fgindex bgindex inherit"/>
     <object name="Editor.Scrollbar" background="FF000001" foreground="FF00000B" flags="fgindex bgindex inherit"/>
     <object name="Editor.Status" background="FF000001" foreground="FF00000F" flags="fgindex bgindex inherit"/>
     <object name="Editor.Text" background="FF000001" foreground="FF00000B" flags="fgindex bgindex inherit"/>

--- a/extra/Addons/Colors/Interface/Colors_from_admin_essp_ru.farconfig
+++ b/extra/Addons/Colors/Interface/Colors_from_admin_essp_ru.farconfig
@@ -51,7 +51,7 @@
     <object name="Dialog.Text" background="FF000007" foreground="FF000000" flags="fgindex bgindex inherit"/>
     <object name="Dialog.Text.Highlight" background="FF000007" foreground="FF00000E" flags="fgindex bgindex inherit"/>
     <object name="Editor.Clock" background="FF000003" foreground="FF000000" flags="fgindex bgindex inherit"/>
-    <!-- <object name="Editor.LineNumbers" background="FF000001" foreground="FF000007" flags="fgindex bgindex ulindex inherit"/> -->
+    <object name="Editor.LineNumbers" background="FF000001" foreground="FF000007" flags="fgindex bgindex inherit"/>
     <object name="Editor.Scrollbar" background="FF000001" foreground="FF00000B" flags="fgindex bgindex inherit"/>
     <object name="Editor.Status" background="FF00000A" foreground="FF000000" flags="fgindex bgindex inherit"/>
     <object name="Editor.Text" background="FF000001" foreground="FF00000B" flags="fgindex bgindex inherit"/>

--- a/extra/Addons/Colors/Interface/FARColors242.farconfig
+++ b/extra/Addons/Colors/Interface/FARColors242.farconfig
@@ -51,7 +51,7 @@
     <object name="Dialog.Text" background="FF000007" foreground="FF000000" flags="fgindex bgindex inherit"/>
     <object name="Dialog.Text.Highlight" background="FF000007" foreground="FF00000F" flags="fgindex bgindex inherit"/>
     <object name="Editor.Clock" background="FF000003" foreground="FF000000" flags="fgindex bgindex inherit"/>
-    <!-- <object name="Editor.LineNumbers" background="FF000001" foreground="FF000007" flags="fgindex bgindex ulindex inherit"/> -->
+    <object name="Editor.LineNumbers" background="FF000008" foreground="FF000007" flags="fgindex bgindex inherit"/>
     <object name="Editor.Scrollbar" background="FF000001" foreground="FF00000B" flags="fgindex bgindex inherit"/>
     <object name="Editor.Status" background="FF000007" foreground="FF000000" flags="fgindex bgindex inherit"/>
     <object name="Editor.Text" background="FF000008" foreground="FF000007" flags="fgindex bgindex inherit"/>

--- a/extra/Addons/Colors/Interface/GreenMile.farconfig
+++ b/extra/Addons/Colors/Interface/GreenMile.farconfig
@@ -51,7 +51,7 @@
     <object name="Dialog.Text" background="FF000007" foreground="FF000000" flags="fgindex bgindex inherit"/>
     <object name="Dialog.Text.Highlight" background="FF000007" foreground="FF00000E" flags="fgindex bgindex inherit"/>
     <object name="Editor.Clock" background="FF00000A" foreground="FF000000" flags="fgindex bgindex inherit"/>
-    <!-- <object name="Editor.LineNumbers" background="FF000001" foreground="FF000007" flags="fgindex bgindex ulindex inherit"/> -->
+    <object name="Editor.LineNumbers" background="FF000002" foreground="FF000007" flags="fgindex bgindex inherit"/>
     <object name="Editor.Scrollbar" background="FF000002" foreground="FF000000" flags="fgindex bgindex inherit"/>
     <object name="Editor.Status" background="FF00000A" foreground="FF000000" flags="fgindex bgindex inherit"/>
     <object name="Editor.Text" background="FF000002" foreground="FF000000" flags="fgindex bgindex inherit"/>

--- a/extra/Addons/Colors/Interface/Rodion_Doroshkevich.farconfig
+++ b/extra/Addons/Colors/Interface/Rodion_Doroshkevich.farconfig
@@ -51,7 +51,7 @@
     <object name="Dialog.Text" background="FF000007" foreground="FF000000" flags="fgindex bgindex inherit"/>
     <object name="Dialog.Text.Highlight" background="FF000007" foreground="FF00000E" flags="fgindex bgindex inherit"/>
     <object name="Editor.Clock" background="FF000003" foreground="FF000000" flags="fgindex bgindex inherit"/>
-    <!-- <object name="Editor.LineNumbers" background="FF000001" foreground="FF000007" flags="fgindex bgindex ulindex inherit"/> -->
+    <object name="Editor.LineNumbers" background="FF000001" foreground="FF000007" flags="fgindex bgindex inherit"/>
     <object name="Editor.Scrollbar" background="FF000001" foreground="FF00000B" flags="fgindex bgindex inherit"/>
     <object name="Editor.Status" background="FF000003" foreground="FF000000" flags="fgindex bgindex inherit"/>
     <object name="Editor.Text" background="FF000001" foreground="FF00000B" flags="fgindex bgindex inherit"/>

--- a/extra/Addons/Colors/Interface/VaxColors.farconfig
+++ b/extra/Addons/Colors/Interface/VaxColors.farconfig
@@ -51,7 +51,7 @@
     <object name="Dialog.Text" background="FF000008" foreground="FF000002" flags="fgindex bgindex inherit"/>
     <object name="Dialog.Text.Highlight" background="FF000008" foreground="FF00000A" flags="fgindex bgindex inherit"/>
     <object name="Editor.Clock" background="FF000003" foreground="FF000000" flags="fgindex bgindex inherit"/>
-    <!-- <object name="Editor.LineNumbers" background="FF000001" foreground="FF000007" flags="fgindex bgindex ulindex inherit"/> -->
+    <object name="Editor.LineNumbers" background="FF000000" foreground="FF000008" flags="fgindex bgindex inherit"/>
     <object name="Editor.Scrollbar" background="FF000001" foreground="FF00000B" flags="fgindex bgindex inherit"/>
     <object name="Editor.Status" background="FF000002" foreground="FF000000" flags="fgindex bgindex inherit"/>
     <object name="Editor.Text" background="FF000000" foreground="FF000002" flags="fgindex bgindex inherit"/>

--- a/extra/Addons/Colors/Interface/black_and_white.farconfig
+++ b/extra/Addons/Colors/Interface/black_and_white.farconfig
@@ -51,7 +51,7 @@
     <object name="Dialog.Text" background="FF000007" foreground="FF000000" flags="fgindex bgindex inherit"/>
     <object name="Dialog.Text.Highlight" background="FF000007" foreground="FF00000F" flags="fgindex bgindex inherit"/>
     <object name="Editor.Clock" background="FF000007" foreground="FF000000" flags="fgindex bgindex inherit"/>
-    <!-- <object name="Editor.LineNumbers" background="FF000001" foreground="FF000007" flags="fgindex bgindex ulindex inherit"/> -->
+    <object name="Editor.LineNumbers" background="FF000000" foreground="FF000008" flags="fgindex bgindex inherit"/>
     <object name="Editor.Scrollbar" background="FF000000" foreground="FF000007" flags="fgindex bgindex inherit"/>
     <object name="Editor.Status" background="FF000007" foreground="FF000000" flags="fgindex bgindex inherit"/>
     <object name="Editor.Text" background="FF000000" foreground="FF000007" flags="fgindex bgindex inherit"/>

--- a/extra/Addons/Colors/Interface/black_from_Fonarev.farconfig
+++ b/extra/Addons/Colors/Interface/black_from_Fonarev.farconfig
@@ -51,7 +51,7 @@
     <object name="Dialog.Text" background="FF000007" foreground="FF000000" flags="fgindex bgindex inherit"/>
     <object name="Dialog.Text.Highlight" background="FF000007" foreground="FF00000E" flags="fgindex bgindex inherit"/>
     <object name="Editor.Clock" background="FF000003" foreground="FF000000" flags="fgindex bgindex inherit"/>
-    <!-- <object name="Editor.LineNumbers" background="FF000001" foreground="FF000007" flags="fgindex bgindex ulindex inherit"/> -->
+    <object name="Editor.LineNumbers" background="FF000000" foreground="FF000008" flags="fgindex bgindex inherit"/>
     <object name="Editor.Scrollbar" background="FF000001" foreground="FF00000B" flags="fgindex bgindex inherit"/>
     <object name="Editor.Status" background="FF000003" foreground="FF000000" flags="fgindex bgindex inherit"/>
     <object name="Editor.Text" background="FF000000" foreground="FF00000B" flags="fgindex bgindex inherit"/>

--- a/extra/Addons/Colors/Interface/black_from_Myodov.farconfig
+++ b/extra/Addons/Colors/Interface/black_from_Myodov.farconfig
@@ -51,7 +51,7 @@
     <object name="Dialog.Text" background="FF000007" foreground="FF000000" flags="fgindex bgindex inherit"/>
     <object name="Dialog.Text.Highlight" background="FF000007" foreground="FF00000E" flags="fgindex bgindex inherit"/>
     <object name="Editor.Clock" background="FF000003" foreground="FF000000" flags="fgindex bgindex inherit"/>
-    <!-- <object name="Editor.LineNumbers" background="FF000001" foreground="FF000007" flags="fgindex bgindex ulindex inherit"/> -->
+    <object name="Editor.LineNumbers" background="FF000000" foreground="FF000008" flags="fgindex bgindex inherit"/>
     <object name="Editor.Scrollbar" background="FF000001" foreground="FF00000B" flags="fgindex bgindex inherit"/>
     <object name="Editor.Status" background="FF000008" foreground="FF000000" flags="fgindex bgindex inherit"/>
     <object name="Editor.Text" background="FF000000" foreground="FF00000F" flags="fgindex bgindex inherit"/>

--- a/extra/Addons/Colors/Interface/black_from_july.farconfig
+++ b/extra/Addons/Colors/Interface/black_from_july.farconfig
@@ -51,7 +51,7 @@
     <object name="Dialog.Text" background="FF000007" foreground="FF000000" flags="fgindex bgindex inherit"/>
     <object name="Dialog.Text.Highlight" background="FF000007" foreground="FF00000C" flags="fgindex bgindex inherit"/>
     <object name="Editor.Clock" background="FF000003" foreground="FF000000" flags="fgindex bgindex inherit"/>
-    <!-- <object name="Editor.LineNumbers" background="FF000001" foreground="FF000007" flags="fgindex bgindex ulindex inherit"/> -->
+    <object name="Editor.LineNumbers" background="FF000000" foreground="FF000008" flags="fgindex bgindex inherit"/>
     <object name="Editor.Scrollbar" background="FF000001" foreground="FF00000B" flags="fgindex bgindex inherit"/>
     <object name="Editor.Status" background="FF000007" foreground="FF000000" flags="fgindex bgindex inherit"/>
     <object name="Editor.Text" background="FF000000" foreground="FF00000F" flags="fgindex bgindex inherit"/>

--- a/extra/Addons/Colors/Interface/dn_like.farconfig
+++ b/extra/Addons/Colors/Interface/dn_like.farconfig
@@ -51,7 +51,7 @@
     <object name="Dialog.Text" background="FF000007" foreground="FF000000" flags="fgindex bgindex inherit"/>
     <object name="Dialog.Text.Highlight" background="FF000007" foreground="FF00000E" flags="fgindex bgindex inherit"/>
     <object name="Editor.Clock" background="FF000003" foreground="FF000000" flags="fgindex bgindex inherit"/>
-    <!-- <object name="Editor.LineNumbers" background="FF000001" foreground="FF000007" flags="fgindex bgindex ulindex inherit"/> -->
+    <object name="Editor.LineNumbers" background="FF000001" foreground="FF000007" flags="fgindex bgindex inherit"/>
     <object name="Editor.Scrollbar" background="FF000001" foreground="FF00000B" flags="fgindex bgindex inherit"/>
     <object name="Editor.Status" background="FF000003" foreground="FF000000" flags="fgindex bgindex inherit"/>
     <object name="Editor.Text" background="FF000001" foreground="FF00000B" flags="fgindex bgindex inherit"/>

--- a/extra/Addons/Colors/Interface/hell.farconfig
+++ b/extra/Addons/Colors/Interface/hell.farconfig
@@ -51,7 +51,7 @@
     <object name="Dialog.Text" background="FF000007" foreground="FF000000" flags="fgindex bgindex inherit"/>
     <object name="Dialog.Text.Highlight" background="FF000007" foreground="FF00000E" flags="fgindex bgindex inherit"/>
     <object name="Editor.Clock" background="FF000003" foreground="FF000000" flags="fgindex bgindex inherit"/>
-    <!-- <object name="Editor.LineNumbers" background="FF000001" foreground="FF000007" flags="fgindex bgindex ulindex inherit"/> -->
+    <object name="Editor.LineNumbers" background="FF000000" foreground="FF000008" flags="fgindex bgindex inherit"/>
     <object name="Editor.Scrollbar" background="FF000001" foreground="FF00000B" flags="fgindex bgindex inherit"/>
     <object name="Editor.Status" background="FF000001" foreground="FF000003" flags="fgindex bgindex inherit"/>
     <object name="Editor.Text" background="FF000000" foreground="FF000007" flags="fgindex bgindex inherit"/>

--- a/extra/Addons/Colors/Interface/nc5pal2.farconfig
+++ b/extra/Addons/Colors/Interface/nc5pal2.farconfig
@@ -51,7 +51,7 @@
     <object name="Dialog.Text" background="FF000007" foreground="FF000000" flags="fgindex bgindex inherit"/>
     <object name="Dialog.Text.Highlight" background="FF000007" foreground="FF00000E" flags="fgindex bgindex inherit"/>
     <object name="Editor.Clock" background="FF000003" foreground="FF000000" flags="fgindex bgindex inherit"/>
-    <!-- <object name="Editor.LineNumbers" background="FF000001" foreground="FF000007" flags="fgindex bgindex ulindex inherit"/> -->
+    <object name="Editor.LineNumbers" background="FF000001" foreground="FF000007" flags="fgindex bgindex inherit"/>
     <object name="Editor.Scrollbar" background="FF000001" foreground="FF00000B" flags="fgindex bgindex inherit"/>
     <object name="Editor.Status" background="FF000003" foreground="FF000000" flags="fgindex bgindex inherit"/>
     <object name="Editor.Text" background="FF000001" foreground="FF00000B" flags="fgindex bgindex inherit"/>


### PR DESCRIPTION
<!-- Thank you for contributing! Please follow the steps below -->

<!-- Enter a brief description of your PR here -->
## Summary

Color schemes are updated for Editor.LineNumbers

<!-- If this PR is relevant to any other issues or existing PRs, link them here --> 
## References

<!-- Please review the items on the PR checklist before submitting -->
## Checklist
- [X] I have followed the [contributing guidelines](https://github.com/FarGroup/FarManager/blob/master/CONTRIBUTING.md).
- [ ] I have discussed this with project maintainers: <!-- add a link to the corresponding issue / discussion / forum topic here --> <br/>
If not checked, I accept that this work might be rejected in favor of a different grand plan.<br/>

<!-- Enter a more detailed description of the PR and any additional comments here -->
## Details
Editor Line Numbers usually darker than normal text with background matching normal text except Green Mile where darker text was barely visible.
