### PR TITLE
Fix msdocs links for chm

### DIFF
--- a/enc/enc_rus/meta/links.js
+++ b/enc/enc_rus/meta/links.js
@@ -2,7 +2,7 @@ function makeLink(a) {
   if (a.className.indexOf("msdocs") === -1) {
     return;
   }
-  a.href = "https://learn.microsoft.com/search/?terms=" + a.text;
+  a.href = "https://learn.microsoft.com/search/?terms=" + a.innerText;
   if (a.className.indexOf("archive") > -1) {
     a.href = a.href + "&dataSource=previousVersions";
   }


### PR DESCRIPTION
.text property is not available in quirks mode

For example see the link in CPM_NATIVE article.