### PR TITLE
Fix for #1086, crash in ConEmu

### DIFF
--- a/far/fileedit.cpp
+++ b/far/fileedit.cpp
@@ -2646,7 +2646,16 @@ intptr_t FileEditor::EditorControl(int Command, intptr_t Param1, void *Param2)
 			Info->Options|=EOPT_SHOWTITLEBAR;
 		if (Global->Opt->EdOpt.ShowKeyBar)
 			Info->Options|=EOPT_SHOWKEYBAR;
-		if (CheckStructSize(Info, &EditorInfo::WindowArea))
+		/* It looks like the ConEmu plugin (latest version 230724, from 2023) calls `ECTL_GETINFO`
+		   with un-initialized EditorInfo. Which means that `StructSize` is not initialized,
+		   and it is often (a lot) bigger than `sizeof(StructSize)`.
+		   I means that a simple `CheckStructSize(Info)` will pass, because it tests for `>=`.
+		   And 2000091480960 is >= 184 :-) (that is a real value seen on a running FAR + ConEmu)
+		   The structure is invalid, so it is dangerous to update `WindowArea` (FAR crashes).
+		   Testing for `==` is not 100% safe, there is a tiny chance to just happen.
+		   But that's one chance out of 2^32 or 2^64 (max-value of `size_t`, architecture dependent).
+		 */
+		if (Info && Info->StructSize == sizeof(*Info) && CheckStructSize(Info, &EditorInfo::WindowArea))
 			Info->WindowArea = GetPosition().as<RECT>();
 	}
 	return result;


### PR DESCRIPTION
<!-- Thank you for contributing! Please follow the steps below -->

<!-- Enter a brief description of your PR here -->
## Description

Solves bug #1086, crash with ConEmu

<!-- If this PR is relevant to any other issues or existing PRs, link them here --> 
## References

<!-- Please review the items on the PR checklist before submitting -->
## Checklist
- [x] I have followed the [contributing guidelines](https://github.com/FarGroup/FarManager/blob/master/CONTRIBUTING.md).
- [ ] I have discussed this with project maintainers: <!-- add a link to the corresponding issue / discussion / forum topic here --> <br/>
If not checked, I accept that this work might be rejected in favor of a different grand plan.<br/>

<!-- Enter a more detailed description of the PR and any additional comments here -->
## Details

The crash started with commit [2acff8e8e](https://github.com/FarGroup/FarManager/commit/2acff8e8eeaaf5c732dc482e15a89953c9462f37), the addition of new fields in EditorInfo: WindowArea and ClientArea.

It looks like the ConEmu plugin (latest version 230724, from 2023) calls `ECTL_GETINFO` with un-initialized EditorInfo. Which means that `StructSize` is not initialized, and it is often (a lot) bigger than `sizeof(StructSize)`.

* https://github.com/ConEmu/ConEmu/blob/master/src/ConEmuPlugin/ConEmuPlugin995.cpp#L357
* https://github.com/ConEmu/ConEmu/blob/master/src/ConEmuPlugin/ConEmuPlugin1900.cpp#L398
* https://github.com/ConEmu/ConEmu/blob/master/src/ConEmuPlugin/ConEmuPlugin2800.cpp#L444
* https://github.com/ConEmu/ConEmu/blob/master/src/ConEmuPlugin/ConEmuPluginA.cpp#L295

I means that a simple `CheckStructSize(Info)` will sometimes pass, because it tests for `>=`.
And 2000091480960 is >= 184 :-) (that is a real value seen on a running FAR + ConEmu)

The structure is invalid, so it is dangerous to update `WindowArea` (FAR crashes).

My fix checks the exact size of the structure.
Testing for `==` is not 100% safe, there is a tiny chance to just happen.
But that's one chance out of 2^32 or 2^64 (max-value of `size_t`, architecture dependent).
