### PR TITLE
Improve centering in Viewer and Editor

### DIFF
--- a/far/editor.cpp
+++ b/far/editor.cpp
@@ -3799,8 +3799,21 @@ void Editor::DoSearchReplace(const SearchReplaceDisposition Disposition)
 
 					const auto TabCurPos = CurPtr->GetTabCurPos();
 
-					if (TabCurPos + SearchLength + 8 > CurPtr->GetLeftPos() + ObjWidth())
-						CurPtr->SetLeftPos(TabCurPos + SearchLength + 8 - ObjWidth());
+//					if (TabCurPos + SearchLength + 8 > CurPtr->GetLeftPos() + ObjWidth())
+//						CurPtr->SetLeftPos(TabCurPos + SearchLength + 8 - ObjWidth());
+
+					//=========== new center screen ========================
+					const int ComfortWidth = ObjWidth() - std::max(8, ObjWidth() / 10); // 72 for 80x25 (margin 8 letters)
+
+					if (TabCurPos + SearchLength <= ComfortWidth)  // фрагмент в пределах ширины экрана (до 72 знака)
+					{
+						CurPtr->SetLeftPos(0);
+					}
+					else // фрагмент за экраном -> центруем
+					{
+						CurPtr->SetLeftPos(std::max<long long>(TabCurPos + SearchLength / 2 - ObjWidth() / 2, 0LL));
+					}
+					//========== end center screen ========================
 
 					const auto CurLineCopy = m_it_CurLine;
 

--- a/far/viewer.cpp
+++ b/far/viewer.cpp
@@ -749,6 +749,26 @@ void Viewer::ShowPage(int nMode)
 				else
 					SelX1 = i.nSelStart - LeftPos;
 
+				//=========== new center screen ========================
+				if (!m_Wrap && AdjustSelPosition)
+				{
+					const int ComfortWidth = ObjWidth() - std::max(8, ObjWidth()/10); // 72 for 80x25 (margin 8 letters)
+
+					if (i.nSelStart + SelectSize <= ComfortWidth) // фрагмент в пределах ширины экрана (до 72 знака)
+					{
+						LeftPos = 0;
+					}
+					else // фрагмент за экраном -> центруем
+					{
+						LeftPos = std::max<long long>(i.nSelStart + SelectSize/2 - ObjWidth()/2, 0LL);
+					}
+
+					AdjustSelPosition = false;
+					Show();
+					return;
+				}
+				//========== end center screen ========================
+
 				if (!m_Wrap && (i.nSelEnd < LeftPos || i.nSelStart >= LeftPos + ScrollbarAdjustedWidth))
 				{
 					if (AdjustSelPosition)


### PR DESCRIPTION
https://forum.farmanager.com/viewtopic.php?t=13944

from (no centered):
<img width="280" height="185" alt="editor-viewer_center" src="https://github.com/user-attachments/assets/23c558eb-db1c-4226-92ee-67494c00f062" />

to centered and + margin:
<img width="280" height="186" alt="Viewer_Editor_centered" src="https://github.com/user-attachments/assets/1f8a0eec-6651-4876-b3a4-55dc6557cfeb" />

(click to large GIF)