### PR TITLE
FTP: fix crash on Far exit caused by stale FLS callback in unloaded module

### DIFF
--- a/plugins/ftp/FStdLib/FARStdlib/fstd_plg.cpp
+++ b/plugins/ftp/FStdLib/FARStdlib/fstd_plg.cpp
@@ -55,6 +55,12 @@ BOOL WINAPI DllMain(HINSTANCE hinst, DWORD reason, LPVOID ptr)
 	{
 		FP_HModule = (HMODULE)hinst;
 		AtExit(idAtExit);
+		// Pin the module in memory: the static CRT registers an FLS callback
+		// pointing into this image, and a thread exiting after FreeLibrary
+		// would invoke it in unmapped memory (AV in LdrShutdownThread).
+		HMODULE self;
+		GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_PIN | GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+		                   (LPCSTR)hinst, &self);
 	}
 
 	BOOL res = FP_PluginStartup(reason);

--- a/plugins/ftp/lib/All.cpp
+++ b/plugins/ftp/lib/All.cpp
@@ -29,6 +29,16 @@ extern "C" FTPPluginInterface* WINAPI FTPQueryInterface(FTPInterface* Info)
  *******************************************************************/
 BOOL WINAPI DllMain(HINSTANCE hinst, DWORD reason, LPVOID ptr)
 {
+	if(reason == DLL_PROCESS_ATTACH)
+	{
+		// Pin the module in memory: the static CRT registers an FLS callback
+		// pointing into this image, and a thread exiting after FreeLibrary
+		// would invoke it in unmapped memory (AV in LdrShutdownThread).
+		HMODULE self;
+		GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_PIN | GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+		                   (LPCSTR)hinst, &self);
+	}
+
 	BOOL rc = FTP_PluginStartup(reason);
 
 	if(reason == DLL_PROCESS_DETACH)


### PR DESCRIPTION
## Problem

Far intermittently crashes on exit with `STATUS_ACCESS_VIOLATION` ("Memory at ... could not be executed") after the FTP plugin was used during the session.

Crash dump analysis (Far 3.0.6699 x64, Windows 11 26200, FarFtp build 278):

- The faulting thread is exiting normally: `RtlUserThreadStart → BaseThreadInitThunk → RtlExitUserThread → LdrShutdownThread → call into unmapped memory`.
- The faulting address (`ftpNotify.fll+0x246C`) lies inside a module found in the minidump's **unloaded** module list.
- The main thread was in `ControlObject::close` unloading plugins at that moment.

The FTP plugin and its `.fll` sub-modules are linked with the static CRT, which registers an FLS callback pointing into the module image. `FreePlugins()` calls `FreeLibrary()` on the sub-modules while other threads that have used that module's CRT (and therefore hold per-thread FLS data for its slot) may still be alive. When such a thread exits after the unload, FLS cleanup in `LdrShutdownThread` invokes the stale callback in unmapped memory.

## Fix

Pin the module image on `DLL_PROCESS_ATTACH` with `GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_PIN)` so it stays mapped until process shutdown, when unloading is safe. Applied to the shared `DllMain` of the `.fll` sub-modules (`plugins/ftp/lib/All.cpp`) and to the FARStdlib `DllMain` used by `FarFtp.dll` itself (`plugins/ftp/FStdLib/FARStdlib/fstd_plg.cpp`), which has the same exposure.

Verified locally: with the fix the image stays mapped after `FreeLibrary` (pin confirmed via `GetModuleHandle` after free); without it the image is unmapped. The crash itself is a shutdown race and reproduced intermittently on exit after FTP transfers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
