### PR TITLE
Use `curl` and `tar` instead of PowerShell cmdlets

### DIFF
--- a/plugins/arclite/arclite.vcxproj
+++ b/plugins/arclite/arclite.vcxproj
@@ -29,8 +29,11 @@
   <ItemDefinitionGroup>
     <PreBuildEvent>
       <Message>Downloading 7-Zip binaries</Message>
-      <Command>if not exist $(Release7ZDll) powershell -c "Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/FarGroup/thirdparty/master/7z-$(Version7Z).zip' -OutFile '7z\7z-$(Version7Z).zip'; Expand-Archive 7z\7z-$(Version7Z).zip -DestinationPath 7z\$(Version7Z)"
-</Command>
+      <Command>if not exist $(Release7ZDll) (
+md "7z\$(Version7Z)"
+curl -s --retry 3 -o "7z\7z-$(Version7Z).zip" "https://raw.githubusercontent.com/FarGroup/thirdparty/master/7z-$(Version7Z).zip"
+tar -xf "7z\7z-$(Version7Z).zip" -C "7z\$(Version7Z)"
+)</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
 </Project>

--- a/plugins/arclite/build.bat
+++ b/plugins/arclite/build.bat
@@ -1,5 +1,5 @@
 @echo off
-  setlocal
+  setlocal enableextensions enabledelayedexpansion
   pushd "%~dp0"
   rem examples:
   rem ---------------------------------------------------------------
@@ -17,7 +17,7 @@
   set "deb_b=N"
   set "clean=N"& set "cleanonly=N"
   set "vcbld=msbuild"
-  set "vcver=16"
+  set "vcver=17"
 
   for %%a in (%*) do call :proc_param %%a
 
@@ -46,9 +46,10 @@ goto :EOF
   for %%p in (cleanonly) do if /i "%%p" == "%~1" set "clean=Y"& set "cleanonly=Y"
   for %%p in (debug dbg) do if /i "%%p" == "%~1" set "deb_b=Y"
   for %%p in (msbuild) do if /i "%%p" == "%~1" set "vcbld=Msbuild"
-  for %%p in (mmake) do if /i "%%p" == "%~1" set "vcbld=nmake"
+  for %%p in (nmake) do if /i "%%p" == "%~1" set "vcbld=nmake"
   for %%p in (15 15.0 141 vc15 2017 vs2017) do if /i "%%p" == "%~1" set "vcver=15"
   for %%p in (16 16.0 142 vc16 2019 vs2019) do if /i "%%p" == "%~1" set "vcver=16"
+  for %%p in (17 17.0 143 vc17 2022 vs2022) do if /i "%%p" == "%~1" set "vcver=17"
 goto :EOF
 
 :init
@@ -90,6 +91,5 @@ goto :EOF
   set "vcmod=32"
   if "%~1" == "64" set "vcmod=64"
   if "%~1" == "arm64" set "vcmod=amd64_arm64"
-  if "%vcver%" == "15" call "%VS150COMNTOOLS%\..\..\VC\Auxiliary\Build\vcvars%vcmod%.bat"
-  if "%vcver%" == "16" call "%VS160COMNTOOLS%\..\..\VC\Auxiliary\Build\vcvars%vcmod%.bat"
+  call "!VS%vcver%0COMNTOOLS!\..\..\VC\Auxiliary\Build\vcvars%vcmod%.bat"
 goto :EOF

--- a/plugins/arclite/changelog
+++ b/plugins/arclite/changelog
@@ -1,3 +1,7 @@
+MZK 2026-09-08 22:20:59-04:00 - build
+
+1. Use `curl` and `tar` instead of Powershell cmdlets
+
 drkns 2026-09-05 10:40:10+01:00 - build 356
 
 1. 7z.dll v26.03.

--- a/plugins/arclite/makefile_vc
+++ b/plugins/arclite/makefile_vc
@@ -53,8 +53,9 @@ depfile:
 
 $(7ZDLL):
 	@echo Downloading 7-Zip binaries
-	powershell -c "Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/FarGroup/thirdparty/master/7z-$(VERSION_7Z).zip' -OutFile '7z\7z-$(VERSION_7Z).zip'; Expand-Archive 7z\7z-$(VERSION_7Z).zip -DestinationPath 7z\$(VERSION_7Z)"
-
+	md "7z\$(VERSION_7Z)"
+	curl -s --retry 3 -o "7z\7z-$(VERSION_7Z).zip" "https://raw.githubusercontent.com/FarGroup/thirdparty/master/7z-$(VERSION_7Z).zip"
+	tar -xf "7z\7z-$(VERSION_7Z).zip" -C "7z\$(VERSION_7Z)"
 
 clean:
 	$(MAKE) -nologo -f makefile_vc -$(MAKEFLAGS) clean BUILD=1

--- a/plugins/luamacro/changelog
+++ b/plugins/luamacro/changelog
@@ -1,3 +1,7 @@
+MZK 2026-09-08 22:20:59-04:00 - build
+
+1. Use `curl` and `tar` instead of Powershell cmdlets
+
 shmuel 2026-08-22 13:31:33+03:00 - build 943
 
 1. Extend macro:about / lm:about.

--- a/plugins/luamacro/makefile_lib_vc
+++ b/plugins/luamacro/makefile_lib_vc
@@ -82,11 +82,10 @@ luafar\keysandcolors.c: luafar\makefarkeys.lua $(COMINC)\farcolor.hpp $(FARDIR)\
 	@echo generating keysandcolors.c
 	@$(LUA) luafar\makefarkeys.lua $(COMINC)\farcolor.hpp $(FARDIR)\uuids.far.dialogs.hpp $@
 
-!ifndef POWERSHELL
-POWERSHELL=powershell
-!endif
 $(LUA): luasdk\$(VERSION_LUASDK)\$(BITPREFIX)$(DIRBIT)\lua51.dll
 luasdk\$(VERSION_LUASDK)\$(BITPREFIX)$(DIRBIT)\lua51.lib: luasdk\$(VERSION_LUASDK)\$(BITPREFIX)$(DIRBIT)\lua51.dll
 luasdk\$(VERSION_LUASDK)\$(BITPREFIX)$(DIRBIT)\lua51.dll:
 	@echo Downloading Lua binaries
-	$(POWERSHELL) -c "Invoke-WebRequest -Uri 'https://raw.githubusercontent.com/FarGroup/thirdparty/master/LuaSDK-$(VERSION_LUASDK).zip' -OutFile 'luasdk\LuaSDK-$(VERSION_LUASDK).zip'; Expand-Archive luasdk\LuaSDK-$(VERSION_LUASDK).zip -DestinationPath luasdk\$(VERSION_LUASDK)
+	md "luasdk\$(VERSION_LUASDK)"
+	curl -s --retry 3 -o "luasdk\LuaSDK-$(VERSION_LUASDK).zip" "https://raw.githubusercontent.com/FarGroup/thirdparty/master/LuaSDK-$(VERSION_LUASDK).zip"
+	tar -xf "luasdk\LuaSDK-$(VERSION_LUASDK).zip" -C "luasdk\$(VERSION_LUASDK)"


### PR DESCRIPTION
## Summary
Replaced `Invoke-WebRequest` and `Expand-Archive` PowerShell cmdlets with `curl` and `tar` commands.

~Added `-NonInteractive` command line parameter to the `powershell` command executed from `plugins/luamacro/makefile_lib_vc`.~

## References
N/A

## Checklist
- [X] I have followed the [contributing guidelines](https://github.com/FarGroup/FarManager/blob/master/CONTRIBUTING.md).
- [ ] I have discussed this with project maintainers: N/A<br/>
If not checked, I accept that this work might be rejected in favor of a different great big ineffable plan.<br/>

## Details
All of a sudden, building `_build/vc/far.slnx` started failing

<details>

<summary>with the following errors</summary>

```
Build started at 8:15 PM...
1>------ Build started: Project: luafar3, Configuration: Debug x64 ------
1>Generate sources
1>Downloading Lua binaries
1>NMAKE : fatal error U1045: spawn failed for 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.EXE' : 0x80070005 Access is denied.
1>
1>
1>Stop.
1>Included: ..\makefile_vc_def_inc
1>Included: ..\..\_build\vc\config\common.mak
1>Included: ..\makefile_vc_target_inc
1>C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(156,5): error MSB3073: The command "nmake -logo -f makefile_lib_vc luafar\flags.c luafar\keysandcolors.c
1>C:\Program Files\Microsoft Visual Studio\2022\Community\MSBuild\Microsoft\VC\v170\Microsoft.CppCommon.targets(156,5): error MSB3073: :VCEnd" exited with code 2.
1>Done building project "luafar3.vcxproj" -- FAILED.
2>------ Build started: Project: luamacro (Plugins\LuaMacro\luamacro), Configuration: Debug x64 ------
2>LINK : fatal error LNK1104: cannot open file 'lua51.lib'
2>Done building project "luamacro.vcxproj" -- FAILED.
========== Build: 0 succeeded, 2 failed, 33 up-to-date, 0 skipped ==========
========== Build completed at 8:15 PM and took 00.664 seconds ==========
```

</details>

Running `nmake -logo -f makefile_lib_vc luafar\flags.c luafar\keysandcolors.c` in `plugins/luamacro` (the command baked into `plugins/luamacro/luafar3.vcxproj`) fails

<details>

<summary>with the same error</summary>

```
>nmake -logo -f makefile_lib_vc luafar\flags.c luafar\keysandcolors.c
Included: ..\makefile_vc_def_inc
Included: ..\..\_build\vc\config\common.mak
Included: ..\makefile_vc_target_inc
Downloading Lua binaries
NMAKE : fatal error U1045: spawn failed for 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.EXE' : 0x80070005 Access is denied.

Stop.
```

</details>

I tracked the issue down to executing `Invoke-WebRequest` cmdlet. `powershell -c "Invoke-WebRequest ...` runs just fine from the (Far) command line, but fails if executed by `nmake`.

~Adding the `-NonInteractive` command line parameter feels like the right thing to do. After all, here we are running PowerShell non-interactively. However, I do not know why it started failing only recently.~

As discussed in the comment, let's use DOS commands instead of PowerShell.